### PR TITLE
Search for password with auth-source

### DIFF
--- a/ement.el
+++ b/ement.el
@@ -93,6 +93,8 @@ by users; ones who do so should know what they're doing.")
           (timeline (lazy_load_members . t))))
   "Default filter for sync requests.")
 
+
+
 ;; From other files.
 (defvar ement-room-avatar-max-width)
 (defvar ement-room-avatar-max-height)
@@ -126,6 +128,16 @@ Writes the session file when Emacs is killed."
   "Hook run after initial sync.
 Run with one argument, the session synced."
   :type 'hook)
+
+
+
+
+
+
+
+
+
+
 
 ;;;; Commands
 


### PR DESCRIPTION
…and reject incorrect user-ids earlier.

This changes the reading interface a little; see the bit with `minibuffer-message`.

We're looking for `:user` and `:host` as they appear in the ID.  I registered my matrix account via an identity server so I actually recorded the password under that hostname and symlinked the `akater@matrix.org` entry to it.  I'm not sure how to deal with this properly.

We do not try to record passwords and while this convenience feature may be added, I'm certain it should be disabled by default.