### PR TITLE
Docs: Describe Pantalaimon usage

### DIFF
--- a/README.org
+++ b/README.org
@@ -174,6 +174,16 @@ Emacs may not display certain symbols and emojis well by default.  Based on [[ht
   (set-fontset-font t 'unicode "Noto Emoji" nil 'append)
 #+END_SRC
 
+*** E2E support with Pantalaimon
+Pantalaimon users may connect with
+
+#+BEGIN_SRC elisp
+(ement-connect :user-id "@USERNAME:SERVER" :password "PASSWORD"
+               :uri-prefix "http://localhost:8009")
+#+END_SRC
+
+where 8009 is to be replaced with the port specified in your Pantalaimon configuration.
+
 * Rationale
 
 Why write a new Emacs Matrix client when there is already [[https://github.com/alphapapa/matrix-client.el][matrix-client.el]], by the same author, no less?  A few reasons:


### PR DESCRIPTION
Port in the example is 8009.  This is the default port according to
man pantalaimon(5) as provided by pantalaimon-0.12.5. The manpage is
dated 2019-08-05.

I tested the suggested code as is, it works.