### PR TITLE
Fix: (ement-room--room-display-name) check for empty room first

### DIFF
--- a/ement-room.el
+++ b/ement-room.el
@@ -1590,16 +1590,16 @@ data slot."
                                 summary))
                     ;; TODO: Disambiguate hero display names.
                     (when hero-ids
-                      (cond ((>= (length hero-ids) (1- (+ joined-count invited-count)))
+                      (cond ((<= (+ joined-count invited-count) 1)
+                             ;; Empty room.
+                             (empty-room hero-ids joined-count))
+                            ((>= (length hero-ids) (1- (+ joined-count invited-count)))
                              ;; Members == heroes.
                              (hero-names hero-ids))
                             ((and (< (length hero-ids) (1- (+ joined-count invited-count)))
                                   (> (+ joined-count invited-count) 1))
                              ;; More members than heroes.
-                             (heroes-and-others hero-ids joined-count))
-                            ((<= (+ joined-count invited-count) 1)
-                             ;; Empty room.
-                             (empty-room hero-ids joined-count))))))
+                             (heroes-and-others hero-ids joined-count))))))
               (hero-names
                (heroes) (string-join (mapcar #'hero-name heroes) ", "))
               (hero-name


### PR DESCRIPTION
The spec for calculating room names is, I think, confusingly specified.

I believe it should not be considered sequentially because subparagraph iii can't be reached if you consider i first.

This change re-orders the branches so that it will check for rooms where the total member count is <= 0 before considering the other possibilities.