### PR TITLE
Fix: (ement-room-compose-from-minibuffer) Inherit minibuffer's input method properly

### DIFF
--- a/ement-room.el
+++ b/ement-room.el
@@ -2423,9 +2423,8 @@ To be called from a minibuffer opened from
                          (add-hook 'window-configuration-change-hook show-buffer-fn-symbol)))))
     (fset compose-fn-symbol compose-fn)
     (add-hook 'minibuffer-exit-hook compose-fn-symbol)
-    ;; If minibuffer's input method is not deactivated, then all
-    ;; minibuffer commands inherit the room's input method.  This is
-    ;; not the correct behaviour.
+    ;; Deactivate minibuffer's input method, otherwise subsequent
+    ;; minibuffers will have it, too.
     (deactivate-input-method)
     (abort-recursive-edit)))
 


### PR DESCRIPTION
Fixes #16.

* `pop-to-buffer' seems to deactivate the buffer's input method.
This meant that users had to explicitly switch to the correct input
method by pressing C-\.

* Without explicitly disabling the input method of the minibuffer,
every minibuffer command inherited the room's input method.  This is
not the desired behaviour.  The solution seems to be to explicitly
deactivate the minibuffer's input method before calling
`abort-recursive-edit'.