### PR TITLE
Fix malformed m.receipt events causing error in process sentinel

### DIFF
--- a/ement.el
+++ b/ement.el
@@ -1179,7 +1179,10 @@ and `session' to the session.  Adds function to
                          ;; NOTE: The JSON map keys are converted to symbols by `json-read'.
                          ;; MAYBE: (Should we keep them that way?  It would use less memory, I guess.)
                          do (puthash (symbol-name user-id)
-                                     (cons (symbol-name event-id) (alist-get 'ts receipt))
+                                     (cons (symbol-name event-id)
+                                           (if (json-alist-p receipt )
+                                               (alist-get 'ts receipt)
+                                             (alist-get 'ts (json-parse-string receipt :object-type 'alist))))
                                      room-receipts)))))
 
 (ement-defevent "m.space.child"


### PR DESCRIPTION
Sometimes I get this error: `error in process sentinel: Wrong type
argument: listp, "{\"ts\": 1553242544352}"` when syncing. It's
happening in the m.receipt event handler. It seems like for some
reason this event, but not all events, hasn't been decoded from json,
or needs to be decoded a second time.

Hopefully this patch is minimal and harmless. An alternative behavior
would be to drop the malformed receipt events.