### PR TITLE
Fix: (ement-room-sync) Correct argument order

### DIFF
--- a/README.org
+++ b/README.org
@@ -262,7 +262,8 @@ Note that, while ~matrix-client~ remains usable, and probably will for some time
 
 ** 0.1.2-pre
 
-Nothing new yet.
+*Fixed*
++ Function ~ement-room-sync~ correctly updates room-list buffers.  (Thanks to [[https://github.com/vizs][Visuwesh]].)
 
 ** 0.1.1
 

--- a/README.org
+++ b/README.org
@@ -260,6 +260,10 @@ Note that, while ~matrix-client~ remains usable, and probably will for some time
 :TOC:      :depth 0
 :END:
 
+** 0.1.2-pre
+
+Nothing new yet.
+
 ** 0.1.1
 
 *Fixed*

--- a/ement-room.el
+++ b/ement-room.el
@@ -1484,7 +1484,7 @@ sync requests.  Also, update any room list buffers."
   (interactive (list ement-session current-prefix-arg))
   (ement--sync session :force force)
   (cl-loop for buffer in (buffer-list)
-           when (member (buffer-local-value buffer 'major-mode)
+           when (member (buffer-local-value 'major-mode buffer)
                         '(ement-taxy-mode ement-room-list-mode))
            do (with-current-buffer buffer
                 (revert-buffer))))

--- a/ement.el
+++ b/ement.el
@@ -5,7 +5,7 @@
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; Maintainer: Adam Porter <adam@alphapapa.net>
 ;; URL: https://github.com/alphapapa/ement.el
-;; Version: 0.1.1
+;; Version: 0.1.2-pre
 ;; Package-Requires: ((emacs "27.1") (map "2.1") (plz "0.2") (taxy "0.9") (taxy-magit-section "0.9") (svg-lib "0.2.5") (transient "0.3.7"))
 ;; Keywords: comm
 


### PR DESCRIPTION
This simply swaps the argument order to the right one 