### PR TITLE
Fix: (ement-notify-dbus-p) dbus-ping with timeout

### DIFF
--- a/README.org
+++ b/README.org
@@ -302,6 +302,7 @@ Note that, while ~matrix-client~ remains usable, and probably will for some time
 *Fixes*
 + Command ~ement-describe-room~ for rooms without topics.
 + Improve insertion of old messages around existing timestamp headers.
++ Reduce D-Bus notification system check timeout to 2 seconds (from the default of 25).
 
 ** 0.2.1
 

--- a/ement-notify.el
+++ b/ement-notify.el
@@ -52,7 +52,10 @@
   (and (featurep 'dbusbind)
        (require 'dbus nil :no-error)
        (dbus-ignore-errors (dbus-get-unique-name :session))
-       (dbus-ping :session "org.freedesktop.Notifications"))
+       ;; By default, emacs waits up to 25 seconds for a PONG.  Realistically, if there's
+       ;; no pong after 2000ms, there's pretty sure no notification service connected or
+       ;; the system's setup has issues.
+       (dbus-ping :session "org.freedesktop.Notifications" 2000))
   "Whether D-Bus notifications are usable.")
 
 ;;;; Customization


### PR DESCRIPTION
Use a 500ms timeout instead of the standard 25 seconds so that loading
ement-notify.el doesn't stall for ages when something DBUS is wonky.

This fixes #98.