### PR TITLE
Change `(setf (point) ...)` to `(goto-char ...)`

### DIFF
--- a/ement-room.el
+++ b/ement-room.el
@@ -2525,7 +2525,8 @@ Also, mark room's buffer as unmodified."
   (interactive)
   (if-let ((fully-read-pos (when ement-room-fully-read-marker
                              (ewoc-location ement-room-fully-read-marker))))
-      (setf (point) fully-read-pos (window-start) fully-read-pos)
+      (progn (goto-char fully-read-pos)
+             (setf (window-start) fully-read-pos))
     ;; Unlike the fully-read marker, there doesn't seem to be a
     ;; simple way to get the user's read-receipt marker.  So if
     ;; we haven't seen either marker in the retrieved events, we


### PR DESCRIPTION
Emacs version 29.0.50 has deprecated the use of forms such as `(setf (point) n)`. The warning emitted is: -

```
Warning (bytecomp): ‘point’ is an obsolete generalized variable; use ‘goto-char’ instead.
```