### PR TITLE
Fix login for non-Synapse servers

### DIFF
--- a/README.org
+++ b/README.org
@@ -298,6 +298,7 @@ Note that, while ~matrix-client~ remains usable, and probably will for some time
 *Fixes*
 + Retry sync for HTTP 502 "Bad Gateway" errors.
 + Formatting of unban events.
++ Update password authentication according to newer Matrix spec.  (Fixes compatibility with Conduit servers.  [[https://github.com/alphapapa/ement.el/issues/66][#66]].  Thanks to [[https://github.com/tpeacock19][Travis Peacock]], [[https://github.com/viiru-][Arto Jantunen]], and [[https://github.com/scd31][Stephen D]].)
 
 ** 0.5.2
 

--- a/ement.el
+++ b/ement.el
@@ -236,7 +236,9 @@ the port, e.g.
                () (pcase-let* (((cl-struct ement-session user device-id initial-device-display-name) session)
                                ((cl-struct ement-user id) user)
                                (data (ement-alist "type" "m.login.password"
-                                                  "user" id
+                                                  "identifier"
+                                                  (ement-alist "type" "m.id.user"
+                                                               "user" id)
                                                   "password" password
                                                   "device_id" device-id
                                                   "initial_device_display_name" initial-device-display-name)))


### PR DESCRIPTION
Closes #66

Confirmed working with a Conduit server and with a Synapse server