### PR TITLE
Add basic support for m.video events

### DIFF
--- a/README.org
+++ b/README.org
@@ -302,6 +302,7 @@ Note that, while ~matrix-client~ remains usable, and probably will for some time
 + Option ~ement-room-timestamp-header-align~ controls how timestamp headers are aligned in room buffers.
 + Option ~ement-room-view-hook~ runs functions when ~ement-room-view~ is called.  (By default, it refreshes the room list buffer.)
 + In the room list, middle-clicking a room which has a buffer closes its buffer.
++ Basic support for video events.  (Thanks to [[https://github.com/viiru-][Arto Jantunen]].)
 
 *Changes*
 

--- a/ement-room.el
+++ b/ement-room.el
@@ -3396,6 +3396,7 @@ If FORMATTED-P, return the formatted body content, when available."
                            ((or "m.text" "m.emote" "m.notice") nil)
                            ("m.image" (ement-room--format-m.image event))
                            ("m.file" (ement-room--format-m.file event))
+                           ("m.video" (ement-room--format-m.video event))
                            (_ (if (or local-redacted-by unsigned-redacted-by)
                                   nil
                                 (format "[unsupported msgtype: %s]" msgtype ))))))
@@ -4123,6 +4124,31 @@ Then invalidate EVENT's node to show the image."
                       (ement--mxc-to-url mxc-url ement-session)))
                (human-size (file-size-human-readable size))
                (string (format "[file: %s (%s) (%s)]" filename mimetype human-size)))
+    (concat (propertize string
+                        'action #'browse-url
+                        'button t
+                        'button-data url
+                        'category t
+                        'face 'button
+                        'follow-link t
+                        'help-echo url
+                        'keymap button-map
+                        'mouse-face 'highlight)
+            (propertize " "
+                        'display '(space :relative-height 1.5)))))
+
+(defun ement-room--format-m.video (event)
+  "Return \"m.video\" EVENT formatted as a string."
+  ;; TODO: Insert thumbnail images when enabled.
+  (pcase-let* (((cl-struct ement-event
+                           (content (map body
+                                         ('info (map mimetype size w h))
+                                         ('url mxc-url))))
+                event)
+               (url (when mxc-url
+                      (ement--mxc-to-url mxc-url ement-session)))
+               (human-size (file-size-human-readable size))
+               (string (format "[video: %s (%s) (%sx%s) (%s)]" body mimetype w h human-size)))
     (concat (propertize string
                         'action #'browse-url
                         'button t


### PR DESCRIPTION
This is very similar to the m.file handler (which would mostly work for videos as well), and is also missing support for thumbnails (however the events I'm seeing don't contain those anyway).

In comparison to ement-room--format-m.file this handler uses content.body as the caption instead of content.filename (which m.video doesn't contain, while m.file does have body). Also the video resolution is shown (<width>x<height>).