### PR TITLE
Fix: avoid spurious indent in room membership changes

### DIFF
--- a/README.org
+++ b/README.org
@@ -308,6 +308,7 @@ Note that, while ~matrix-client~ remains usable, and probably will for some time
 
 *Fixes*
 + Minor adjustment to timestamp headers.
++ Extra indentation of some membership events.  (Thanks to [[https://github.com/Stebalien][Steven Allen]].)
 + Customization group for faces.
 
 ** 0.9.3

--- a/ement-room.el
+++ b/ement-room.el
@@ -3698,12 +3698,10 @@ a copy of the local keymap, and sets `header-line-format'."
 (define-widget 'ement-room-membership 'item
   "Widget for membership events."
   ;; FIXME: This makes it hard to add a timestamp according to the buffer's message format spec.
-
-  ;; FIXME: The widget value inserts an extra space before the wrap prefix.  There seems
-  ;; to be no way to fix this while still using a widget for this, so maybe we shouldn't
-  ;; use a widget after all.  But it might be good to keep digging for a solution so that
-  ;; widgets could be used for other things later...
-  :format "%{ %v %}"
+  ;; NOTE: The widget needs something before and after "%v" to correctly apply the
+  ;; `ement-room-membership' face. We could use a zero-width space, but that won't work on
+  ;; a TTY. So we use a regular space but replace it with nothing with a display spec.
+  :format (let ((zws (propertize " " 'display ""))) (concat "%{" zws "%v" zws "%}"))
   :sample-face 'ement-room-membership
   :value-create (lambda (widget)
                   (pcase-let* ((event (widget-value widget)))

--- a/ement-room.el
+++ b/ement-room.el
@@ -3701,7 +3701,8 @@ a copy of the local keymap, and sets `header-line-format'."
   ;; NOTE: The widget needs something before and after "%v" to correctly apply the
   ;; `ement-room-membership' face. We could use a zero-width space, but that won't work on
   ;; a TTY. So we use a regular space but replace it with nothing with a display spec.
-  :format (let ((zws (propertize " " 'display ""))) (concat "%{" zws "%v" zws "%}"))
+  :format (let ((zws (propertize " " 'display "")))
+            (concat "%{" zws "%v" zws "%}"))
   :sample-face 'ement-room-membership
   :value-create (lambda (widget)
                   (pcase-let* ((event (widget-value widget)))


### PR DESCRIPTION
Propertize the spaces in the widget's format string to hide them. We could, alternatively, use a zero-width space... but that won't work on a TTY.

This is a bit of a hack but it looks much nicer.