### PR TITLE
fix: only autoload when scrolling past the top

### DIFF
--- a/README.org
+++ b/README.org
@@ -310,6 +310,7 @@ Note that, while ~matrix-client~ remains usable, and probably will for some time
 + Extra indentation of some membership events.  (Thanks to [[https://github.com/Stebalien][Steven Allen]].)
 + Customization group for faces.
 + Don't reinitialize ~ement-room-list-mode~ when room list buffer is refreshed.  ([[https://github.com/alphapapa/ement.el/issues/146][#146]].  Thanks to [[https://github.com/treed][Ted Reed]] for reporting.)
++ Don't fetch old events when scrolling to the bottom of a room buffer (only when scrolling to the top).  (Thanks to [[https://github.com/Stebalien][Steven Allen]].)
 
 ** 0.9.3
 

--- a/ement-room.el
+++ b/ement-room.el
@@ -1398,10 +1398,9 @@ see."
   "Scroll according to EVENT, loading earlier messages when at top."
   (interactive "e")
   (with-selected-window (posn-window (event-start event))
-    (let ((start (window-start)))
-      (mwheel-scroll event)
-      (when (= start (window-start))
-        (call-interactively #'ement-room-retro)))))
+    (mwheel-scroll event)
+    (when (= (point-min) (window-start))
+      (call-interactively #'ement-room-retro))))
 
 ;; TODO: Unify these retro-loading functions.
 


### PR DESCRIPTION
Previously, this would attempt to retrieve old events whenever scrolling did nothing. Even when we were at the bottom of the buffer.

(I can update the changelog, but I don't think this warrants it)