### PR TITLE
Enable image-mode when displaying images in a new buffer

### DIFF
--- a/README.org
+++ b/README.org
@@ -304,6 +304,7 @@ Note that, while ~matrix-client~ remains usable, and probably will for some time
 + Command ~ement-room-image-show-mouse~ is used to show an image with the mouse.
 
 *Changes*
++ Enable ~image-mode~ when showing images in a new buffer.  (Thanks to [[https://github.com/Stebalien][Steven Allen]].)
 + Command ~ement-room-image-show~ is not used for mouse events.
 + Show useful message in SSO login page.
 

--- a/ement-room.el
+++ b/ement-room.el
@@ -4050,7 +4050,8 @@ height."
           (image-property image :max-height) nil)
     (with-current-buffer new-buffer
       (erase-buffer)
-      (insert-image image))
+      (insert-image image)
+      (image-mode))
     (pop-to-buffer new-buffer '((display-buffer-pop-up-frame)))
     (set-frame-parameter nil 'fullscreen 'maximized)))
 


### PR DESCRIPTION
This makes it easy to, e.g., zoom the image (and prevents any attempts to edit it, add text to the buffer, etc.).