### PR TITLE
Support RET/M-RET for viewing/scaling images

### DIFF
--- a/README.org
+++ b/README.org
@@ -299,7 +299,11 @@ Note that, while ~matrix-client~ remains usable, and probably will for some time
 
 ** 0.11-pre
 
-Nothing new yet.
+*Additions*
++ Images can now be scaled and viewed with the keyboard. Use the ~ement-room-image-show~ and ~ement-room-image-scale~ commands (bound to ~RET~ and ~M-RET~ by default when an image is selected).
+
+*Changes*
++ Command ~ement-room-image-show~ no longer expects to be bound to a mouse button, bind ~ement-room-image-show-mouse~.
 
 ** 0.10
 


### PR DESCRIPTION
Refactor `ement-room-image-show` to `ement-room-image-show` and `ement-room-image-show-mouse`. Ditto for `-image-scale-`. Then bind RET/M-RET to these new commands.

NOTE: this renames `ement-room-image-show` to `ement-room-image-show-mouse` for consistency (breaking).

If you'd like to avoid the breaking change, I can rename these functions to `-at-point` and `-mouse`, and turn the existing versions into aliases.