### PR TITLE
Fix room list display with empty notification actions

### DIFF
--- a/README.org
+++ b/README.org
@@ -309,6 +309,7 @@ Note that, while ~matrix-client~ remains usable, and probably will for some time
 
 *Fixes*
 + Allow editing of already-edited events.
++ Push rules' actions may be listed in any order.  (Fixes compatibility with [[https://spec.matrix.org/v1.7/client-server-api/#actions][v1.7 of the spec]].  Thanks to [[https://github.com/Stebalien][Steven Allen]].)
 + Call external browser for SSO login page.  (JavaScript is usually required, which EWW doesn't support, and loading the page twice seems to change state on the server that causes the SSO login to fail, so it's best to load the page in the external browser directly).
 + Clean up SSO server process after two minutes in case SSO login fails.
 + Don't stop syncing if an error is signaled while sending a notification.

--- a/ement-lib.el
+++ b/ement-lib.el
@@ -597,12 +597,12 @@ Returns one of nil (meaning default rules are used), `all-loud',
                                          (equal "room_id" key)
                                          (equal (ement-room-id room) pattern)))))
                 (mute-rule-p
-                 (rule) (and (= 1 (length (alist-get 'actions rule)))
-                             (equal "dont_notify" (elt (alist-get 'actions rule) 0))))
+                 (rule) (when-let ((actions (alist-get 'actions rule)))
+                          (seq-contains-p actions "dont_notify")))
                 (tweak-rule-p
-                 (type rule) (pcase-let (((map ('actions `[,action ,alist])) rule))
-                               (and (equal "notify" action)
-                                    (equal type (alist-get 'set_tweak alist))))))
+                 (type rule) (when-let ((actions (alist-get 'actions rule)))
+                               (and (seq-contains-p actions "notify")
+                                    (seq-contains-p actions `(set_tweak . ,type) 'seq-contains-p)))))
       ;; If none of these match, nil is returned, meaning that the default rule is used
       ;; for the room.
       (if (override-mute-rule-for-room-p room)

--- a/ement-lib.el
+++ b/ement-lib.el
@@ -41,6 +41,7 @@
 
 (require 'color)
 (require 'map)
+(require 'seq)
 (require 'xml)
 
 (require 'ement-api)


### PR DESCRIPTION
Parse actions according to https://spec.matrix.org/v1.7/client-server-api/#actions, allowing for 0 or more actions in any order.

fixes #181