### PR TITLE
wip: add ement-room-compose-send-functions

### DIFF
--- a/ement-room.el
+++ b/ement-room.el
@@ -3649,12 +3649,8 @@ To be called from a minibuffer opened from
     (deactivate-input-method)
     (abort-recursive-edit)))
 
-(defun ement-room-compose-send ()
-  "Prompt to send the current compose buffer's contents.
-To be called from an `ement-room-compose' buffer."
-  (interactive)
-  (cl-assert ement-room-compose-buffer)
-  (cl-assert ement-room) (cl-assert ement-session)
+(defun ement-room--compose-send-default ()
+  "Send `ement-room-compose' contents to minibuffer."
   ;; Putting it in the kill ring seems like the best thing to do, to ensure
   ;; it doesn't get lost if the user exits the minibuffer before sending.
   (kill-new (string-trim (buffer-string)))
@@ -3677,6 +3673,21 @@ To be called from an `ement-room-compose' buffer."
                        (ement-room-read-string prompt (car kill-ring) nil nil 'inherit-input-method))
                    (ement-room-read-string prompt (car kill-ring) nil nil 'inherit-input-method)) ))
       (ement-room-send-message ement-room ement-session :body body :replying-to-event replying-to-event))))
+
+(defcustom ement-room-compose-send-functions '(ement-room--compose-send-default)
+  "Hook run in `ement-room-compose' buffer when `ement-room-compose-send' invoked."
+  :type 'hook)
+
+(defun ement-room-compose-send ()
+  "Prompt to send the current compose buffer's contents.
+To be called from an `ement-room-compose' buffer."
+  (interactive)
+  (cl-assert ement-room-compose-buffer)
+  (cl-assert ement-room) (cl-assert ement-session)
+  (let ((ement-room-compose-send-functions
+         ;; Should we prevent nil hook binding here?
+         (or ement-room-compose-send-functions '(ement-room--compose-send-default))))
+      (run-hooks 'ement-room-compose-send-functions)))
 
 (defun ement-room-init-compose-buffer (room session)
   "Eval BODY, setting up the current buffer as a compose buffer.


### PR DESCRIPTION
Proof of  concept for replacing the single message filter function with a hook.
The hook could be configured like so:

For those who want to skip the minibuffer confirmation after sending from a compose buffer:

```emacs-lisp
(defun +ement--exit-minibuffer-once ()
  "Exit the minibuffer once after `ement-compose-message-send'."
  (remove-hook 'post-command-hook #'+ement--exit-minibuffer-once)
  (exit-minibuffer))

(defun +ement--install-minibuffer-skip ()
  "Automatically exit minibuffer after change."
  (add-hook 'post-command-hook #'+ement--exit-minibuffer-once))
(add-hook 'ement-room-compose-send-functions #'+ement--install-minibuffer-skip)
```

A silly example:

```emacs-lisp
(defun +ement-censor-message ()
  "Censor messages containing bad words."
  (save-excursion
    (goto-char (point-min))
    (while (re-search-forward "bad" nil t)
      (replace-match "b**"))))
(add-hook 'ement-room-compose-send-functions #'+ement-censor-message -90)
```

A less silly example:

```emacs-lisp
(defun +ement-force-spellcheck ()
  "Force me to spell check a message before sending."
  (require 'flyspell)
  (flyspell-buffer)
  (save-excursion
    (goto-char (point-min))
    (while (text-property-search-forward 'face 'flyspell-incorrect)
      (flyspell-correct-at-point))))
(add-hook 'ement-room-compose-send-functions #'+ement-force-spellcheck -90)
```

