### PR TITLE
Configurable emoji reaction picker

### DIFF
--- a/README.org
+++ b/README.org
@@ -299,6 +299,9 @@ Ement.el doesn't support encrypted rooms natively, but it can be used transparen
 
 *Additions*
 
++ Configurable emoji picker for sending reactions.  ([[https://github.com/alphapapa/ement.el/issues/199][#199]], [[https://github.com/alphapapa/ement.el/pull/201][#201]].  Thanks to [[https://github.com/oantolin][Omar Antolín Camarena]].)
+  - Option ~ement-room-reaction-picker~ sets the default picker.  Within that, the user may press ~C-g~ to choose a different one with a key bound in ~ement-room-reaction-map~.
+
 + A variety of enhancements for using compose buffers.  ([[https://github.com/alphapapa/ement.el/issues/140][#140]].  Thanks to [[https://github.com/phil-s][Phil Sainty]].)
   - Option ~ement-room-compose-buffer-display-action~ declares how and where a new compose buffer window should be displayed.  (By default, in a new window below the associated room buffer.)
   - Option ~ement-room-compose-buffer-window-dedicated~ determines whether compose buffers will have dedicated windows.

--- a/ement-room.el
+++ b/ement-room.el
@@ -263,7 +263,7 @@ makes a best effort to keep it accurate.")
     (when (commandp 'emoji-search)
       (define-key map "s" 'emoji-search))
     (when (assoc "emoji" input-method-alist)
-      (define-key map "m" #'ement-room-use-emoji-input-method))
+      (define-key map "m" 'ement-room-use-emoji-input-method))
     map)
   "Keymap used in `ement-room-send-reaction'.")
 
@@ -748,9 +748,9 @@ To do the same in lisp code, set the option with `setopt'."
   :type 'key-sequence
   :set #'ement-room-self-insert-option-setter)
 
-(defcustom ement-room-reaction-picker (if (commandp #'emoji-insert)
-                                            #'emoji-insert
-                                          #'insert-char)
+(defcustom ement-room-reaction-picker (if (commandp 'emoji-insert)
+                                          'emoji-insert
+                                        #'insert-char)
   "Command used to select a reaction by `ement-room-send-reaction'.
 Should be set to a command that somehow prompts the user for an
 emoji and inserts it into the current buffer.  In Emacs 29

--- a/ement-room.el
+++ b/ement-room.el
@@ -255,6 +255,15 @@ makes a best effort to keep it accurate.")
     map)
   "Keymap used in `ement-room-read-string'.")
 
+(defvar ement-room-reaction-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "c" #'insert-char)
+    (define-key map "i" 'emoji-insert)
+    (define-key map "s" 'emoji-search)
+    (define-key map "m" #'ement-room-select-emoji-input-method)
+    map)
+  "Keymap used in `ement-room-send-reaction'.")
+
 (defvar ement-room-sender-in-headers nil
   "Non-nil when sender is displayed in headers.
 In that case, sender names are aligned to the margin edge.")
@@ -735,6 +744,24 @@ via the setter function `ement-room-self-insert-option-setter'.
 To do the same in lisp code, set the option with `setopt'."
   :type 'key-sequence
   :set #'ement-room-self-insert-option-setter)
+
+(defcustom ement-room-reaction-picker (if (commandp #'emoji-insert)
+                                            #'emoji-insert
+                                          #'insert-char)
+  "Command used to select a reaction by `ement-room-send-reaction'.
+Should be set to a command that somehow prompts the user for an
+emoji and inserts it into the current buffer.  In Emacs 29
+reasonable choices include `emoji-insert' which uses a transient
+interface, and `emoji-search' which uses `completing-read'.  If
+those are not available, one can use `insert-char'."
+  :type '(choice
+          (const :tag "Complete unicode character name" insert-char)
+          (const :tag "Complete emoji name" emoji-search)
+          (const :tag "Transient emoji menu" emoji-insert)
+          (const :tag "Emoji input method"
+                 ement-room-select-emoji-input-method)
+          (const :tag "Type an emoji without assistance" ignore)
+          (function :tag "Use other command")))
 
 (defvar ement-room-sender-in-left-margin nil
   "Whether sender is shown in left margin.
@@ -2219,17 +2246,38 @@ Interactively, to event at point."
                    (replying-to-event (ement--original-event-for event ement-session)))
         (ement-room-send-message room session :body body :replying-to-event replying-to-event)))))
 
+(defun ement-room-select-emoji-input-method ()
+  "Activate the emoji input method in the current buffer."
+  (interactive)
+  (set-input-method "emoji"))
+
 (defun ement-room-send-reaction (key position &optional event)
   "Send reaction of KEY to event at POSITION.
-Interactively, send reaction to event at point.  KEY should be a
-reaction string, e.g. \"👍\"."
+KEY should be a reaction string, e.g. \"👍\".
+
+Interactively, send reaction to event at point.  The user option
+`ement-room-reaction-picker' controls how the reaction string
+is selected, or rather controls the initial mechanism, since the
+user can always cancel that command with \\[keyboard-quit] and
+choose a different one using the key bindings in
+`ement-room-reaction-map' (note that other than `insert-char',
+these all require at least version 29 of Emacs):
+
+\\{ement-room-reaction-map}"
   (interactive
    (let ((event (ewoc-data (ewoc-locate ement-ewoc))))
      (unless (ement-event-p event)
        (user-error "No event at point"))
-     (list (char-to-string (read-char-by-name "Reaction (prepend \"*\" for substring search): "))
-           (point)
-           event)))
+     (list (minibuffer-with-setup-hook
+               (lambda ()
+                 (setq-local after-change-functions
+                             (list (lambda (&rest _) (exit-minibuffer))))
+                 (use-local-map
+                  (make-composed-keymap ement-room-reaction-map (current-local-map)))
+                 (let ((enable-recursive-minibuffers t))
+                   (funcall ement-room-reaction-picker)))
+             (read-string "Reaction: "))
+           (point))))
   ;; SPEC: MSC2677 <https://github.com/matrix-org/matrix-doc/pull/2677>
   ;; HACK: We could simplify this by storing the key in a text property...
   (ement-room-with-highlighted-event-at position


### PR DESCRIPTION
I think this is ready to merge (and addresses #199), but note that it offers you the Emacs 29 emoji commands as options even if you don't have them. Likewise it binds them to keys. The docstring do mention you need Emacs 29 to use them, but maybe you'd want them to not even appear. 