### PR TITLE
Change: use dedicated buffer for message rendering, formatting

### DIFF
--- a/ement-room.el
+++ b/ement-room.el
@@ -3318,13 +3318,14 @@ Format defaults to `ement-room-message-format-spec', which see."
         (left-margin-width ement-room-left-margin-width)
         (right-margin-width ement-room-right-margin-width))
     ;; Copied from `format-spec'.
-    (with-temp-buffer
+    (with-current-buffer (get-buffer-create " *ement-room--format-message*")
       ;; Pretend this is a room buffer.
       (setf ement-session session
             ement-room room)
       ;; HACK: Setting these buffer-locally in a temp buffer is ugly.
       (setq-local ement-room-left-margin-width left-margin-width)
       (setq-local ement-room-right-margin-width right-margin-width)
+      (erase-buffer)
       (insert format)
       (goto-char (point-min))
       (while (search-forward "%" nil t)
@@ -3455,7 +3456,8 @@ If FORMATTED-P, return the formatted body content, when available."
 (defun ement-room--render-html (string)
   "Return rendered version of HTML STRING.
 HTML is rendered to Emacs text using `shr-insert-document'."
-  (with-temp-buffer
+  (with-current-buffer (get-buffer-create " *ement-room--render-html*")
+    (erase-buffer)
     (insert string)
     (save-excursion
       ;; NOTE: We workaround `shr`'s not indenting the blockquote properly (it


### PR DESCRIPTION
(ement-room--format-message):
(ement-room--render-html):
Prefer single buffer over allocating temp-buffer for each call. This should be perform better and reduce garbage.
See: #209