### PR TITLE
Add basic support for m.audio events

### DIFF
--- a/README.org
+++ b/README.org
@@ -297,6 +297,7 @@ Ement.el doesn't support encrypted rooms natively, but it can be used transparen
 
 *Additions*
 
++ Audio events are rendered as a link to the audio file.  (Thanks to [[https://github.com/viiru-][Arto Jantunen]].)
 + Customization group ~ement-room-list~.
 + Option ~ement-room-list-space-prefix~ is applied to space names in the room list (e.g. set to empty string for cleaner appearance).
 + Option ~ement-room-reaction-names-limit~ sets how many senders of a reaction are shown in the buffer (more than that many are shown in the tooltip).

--- a/ement-room.el
+++ b/ement-room.el
@@ -3508,6 +3508,7 @@ If FORMATTED-P, return the formatted body content, when available."
                            ("m.image" (ement-room--format-m.image event))
                            ("m.file" (ement-room--format-m.file event))
                            ("m.video" (ement-room--format-m.video event))
+                           ("m.audio" (ement-room--format-m.audio event))
                            (_ (if (or local-redacted-by unsigned-redacted-by)
                                   nil
                                 (format "[unsupported msgtype: %s]" msgtype ))))))
@@ -4294,6 +4295,31 @@ Then invalidate EVENT's node to show the image."
                       (ement--mxc-to-url mxc-url ement-session)))
                (human-size (file-size-human-readable size))
                (string (format "[video: %s (%s) (%sx%s) (%s)]" body mimetype w h human-size)))
+    (concat (propertize string
+                        'action #'browse-url
+                        'button t
+                        'button-data url
+                        'category t
+                        'face 'button
+                        'follow-link t
+                        'help-echo url
+                        'keymap button-map
+                        'mouse-face 'highlight)
+            (propertize " "
+                        'display '(space :relative-height 1.5)))))
+
+(defun ement-room--format-m.audio (event)
+  "Return \"m.audio\" EVENT formatted as a string."
+  (pcase-let* (((cl-struct ement-event
+                           (content (map body
+                                         ('info (map mimetype duration size))
+                                         ('url mxc-url))))
+                event)
+               (url (when mxc-url
+                      (ement--mxc-to-url mxc-url ement-session)))
+               (human-size (file-size-human-readable size))
+               (human-duration (format-seconds "%m:%s" (/ duration 1000)))
+               (string (format "[audio: %s (%s) (%s) (%s)]" body mimetype human-duration human-size)))
     (concat (propertize string
                         'action #'browse-url
                         'button t


### PR DESCRIPTION
Very similar to the m.video handler (which is very similar to the m.file handler).

Again uses the message body as the title, and displays both audio duration and size.