### PR TITLE
Fix: (ement-room--format-message) %W considers only the current line

### DIFF
--- a/README.org
+++ b/README.org
@@ -348,6 +348,7 @@ Ement.el doesn't support encrypted rooms natively, but it can be used transparen
 *Fixes*
 + Toggling images to fill the window body no longer triggers unintended scrolling.  (Thanks to [[https://github.com/phil-s][Phil Sainty]].)
 + Recognition of mentions after a newline.  ([[https://github.com/alphapapa/ement.el/issues/267][#267]].  Thanks to [[https://github.com/phil-s][Phil Sainty]].)
++ Newlines in ~ement-room-message-format-spec~ are considered when calculating the wrap-prefix.  (Thanks to [[https://github.com/phil-s][Phil Sainty]].)
 
 ** 0.14
 

--- a/ement-room.el
+++ b/ement-room.el
@@ -3898,11 +3898,11 @@ Format defaults to `ement-room-message-format-spec', which see."
       ;; Propertize margin text.
       (when ement-room--format-message-wrap-prefix
         (when-let ((wrap-prefix-end (next-single-property-change (point-min) 'wrap-prefix-end)))
-          (let* ((prefix-width (string-width
-                                (buffer-substring-no-properties (point-min) wrap-prefix-end)))
+          (goto-char wrap-prefix-end)
+          (delete-char 1)
+          (let* ((prefix-width (string-width (buffer-substring-no-properties
+                                              (line-beginning-position) (point))))
                  (prefix (propertize " " 'display `((space :width ,prefix-width)))))
-            (goto-char wrap-prefix-end)
-            (delete-char 1)
             ;; We apply the prefix to the entire event as `wrap-prefix', and to just the
             ;; body as `line-prefix'.
             (put-text-property (point-min) (point-max) 'wrap-prefix prefix)


### PR DESCRIPTION
When the format contains newlines, only the line containing %W is used to establish the width of the wrap-prefix.  Previously the widths of any preceding lines were included as well.

Closes #182.