### PR TITLE
fix: Make sure the matched string is not simply a substring of a bigger word

### DIFF
--- a/ement-room.el
+++ b/ement-room.el
@@ -3589,7 +3589,7 @@ HTML is rendered to Emacs text using `shr-insert-document'."
     (when body
       (cl-macrolet ((matches-body-p
                       (form) `(when-let ((string ,form))
-                                (string-match-p (regexp-quote string) body))))
+                                (string-match-p (format "\\b%s\\b" (regexp-quote string)) body))))
         (or (matches-body-p (ement-user-username user))
             (matches-body-p (ement--user-displayname-in room user))
             (matches-body-p (ement-user-id user)))))))


### PR DESCRIPTION
If one displayname is 'sam' and another's nickname is 'samy', then all events to samy were recognized as mentionning sam as well.

I figured this out because my displayname is sam and all events with the word same where found as mentionning me.