### PR TITLE
Fix: (ement-room-send-reaction) Bail out early when there's no event at point

### DIFF
--- a/README.org
+++ b/README.org
@@ -311,6 +311,7 @@ Ement.el doesn't support encrypted rooms natively, but it can be used transparen
 + Insertion of sender headers (when using "Elemental" message format).  (Refactoring contributed by [[https://github.com/Stebalien][Steven Allen]].)
 + Some room event data was being unintentionally serialized to disk when caching the room list visibility state. ([[https://github.com/alphapapa/ement.el/issues/256][#256]])
 + Notifications buffer restores properly when bookmarked.
++ Command ~ement-room-send-reaction~ checks for an event at point.  (Thanks to [[https://github.com/phil-s][Phil Sainty]].)
 
 ** 0.13
 

--- a/ement-room.el
+++ b/ement-room.el
@@ -716,27 +716,28 @@ number (to darken rather than lighten)."
   "Highlight event at POSITION while evaluating BODY."
   ;; MAYBE: Accept a marker for POSITION.
   (declare (indent 1))
-  `(let* ((node (ewoc-locate ement-ewoc ,position))
-          (event (ewoc-data node))
-          ement-room-replying-to-overlay)
-     (unless (and (ement-event-p event)
-                  (ement-event-id event))
-       (error "No event at point"))
-     (unwind-protect
-         (progn
-           (setf ement-room-replying-to-overlay
-                 (make-overlay (ewoc-location node)
-                               ;; NOTE: It doesn't seem possible to get the end position of
-                               ;; a node, so if there is no next node, we use point-max.
-                               ;; But this might break if we were to use an EWOC footer.
-                               (if (ewoc-next ement-ewoc node)
-                                   (ewoc-location (ewoc-next ement-ewoc node))
-                                 (point-max))))
-           (overlay-put ement-room-replying-to-overlay 'face 'highlight)
-           ,@body)
-       (when (overlayp ement-room-replying-to-overlay)
-         (delete-overlay ement-room-replying-to-overlay))
-       (setf ement-room-replying-to-overlay nil))))
+  (let ((node/g (gensym "node")) (event/g (gensym "event")))
+    `(let* ((,node/g (ewoc-locate ement-ewoc ,position))
+            (,event/g (ewoc-data ,node/g))
+            ement-room-replying-to-overlay)
+       (unless (and (ement-event-p ,event/g)
+                    (ement-event-id ,event/g))
+         (error "No event at point"))
+       (unwind-protect
+           (progn
+             (setf ement-room-replying-to-overlay
+                   (make-overlay (ewoc-location ,node/g)
+                                 ;; NOTE: It doesn't seem possible to get the end position of
+                                 ;; a node, so if there is no next node, we use point-max.
+                                 ;; But this might break if we were to use an EWOC footer.
+                                 (if (ewoc-next ement-ewoc ,node/g)
+                                     (ewoc-location (ewoc-next ement-ewoc ,node/g))
+                                   (point-max))))
+             (overlay-put ement-room-replying-to-overlay 'face 'highlight)
+             ,@body)
+         (when (overlayp ement-room-replying-to-overlay)
+           (delete-overlay ement-room-replying-to-overlay))
+         (setf ement-room-replying-to-overlay nil)))))
 
 (defmacro ement-room-with-typing (&rest body)
   "Send typing notifications around BODY.

--- a/ement-room.el
+++ b/ement-room.el
@@ -1783,17 +1783,22 @@ Interactively, to event at point."
                    (replying-to-event (ement--original-event-for event ement-session)))
         (ement-room-send-message room session :body body :replying-to-event replying-to-event)))))
 
-(defun ement-room-send-reaction (key position)
+(defun ement-room-send-reaction (key position &optional event)
   "Send reaction of KEY to event at POSITION.
 Interactively, send reaction to event at point.  KEY should be a
 reaction string, e.g. \"👍\"."
   (interactive
-   (list (char-to-string (read-char-by-name "Reaction (prepend \"*\" for substring search): "))
-         (point)))
+   (let ((event (ewoc-data (ewoc-locate ement-ewoc))))
+     (unless (ement-event-p event)
+       (user-error "No event at point"))
+     (list (char-to-string (read-char-by-name "Reaction (prepend \"*\" for substring search): "))
+           (point)
+           event)))
   ;; SPEC: MSC2677 <https://github.com/matrix-org/matrix-doc/pull/2677>
   ;; HACK: We could simplify this by storing the key in a text property...
   (ement-room-with-highlighted-event-at position
-    (pcase-let* ((event (or (ewoc-data (ewoc-locate ement-ewoc position))
+    (pcase-let* ((event (or event
+                            (ewoc-data (ewoc-locate ement-ewoc position))
                             (user-error "No event at point")))
                  ;; NOTE: Sadly, `face-at-point' doesn't work here because, e.g. if
                  ;; hl-line-mode is enabled, it only returns the hl-line face.


### PR DESCRIPTION
Don't read the reaction from the user if it can't be used.
