### PR TITLE
Tidy: Use custom docstring for ement-room-mode-hook

### DIFF
--- a/ement-room.el
+++ b/ement-room.el
@@ -2089,10 +2089,10 @@ the previously oldest event."
       ;; We don't really care about the response, I think.
       :then #'ignore)))
 
-;; Due to Emacs bug#68600, define the mode hook separately to avoid the mode
-;; line constructs in the `ement-room-mode' mode name being copied verbatim
-;; into the auto-generated docstring.
 (defcustom ement-room-mode-hook nil
+  ;; Due to Emacs bug#68600, define the mode hook separately to avoid the mode
+  ;; line constructs in the `ement-room-mode' mode name being copied verbatim
+  ;; into the auto-generated docstring.
   "Hook run after entering `ement-room-mode'."
   :options '(visual-line-mode)
   :type 'hook)

--- a/ement-room.el
+++ b/ement-room.el
@@ -2089,6 +2089,14 @@ the previously oldest event."
       ;; We don't really care about the response, I think.
       :then #'ignore)))
 
+;; Due to Emacs bug#68600, define the mode hook separately to avoid the mode
+;; line constructs in the `ement-room-mode' mode name being copied verbatim
+;; into the auto-generated docstring.
+(defcustom ement-room-mode-hook nil
+  "Hook run after entering `ement-room-mode'."
+  :options '(visual-line-mode)
+  :type 'hook)
+
 (define-derived-mode ement-room-mode fundamental-mode
   `("Ement-Room"
     (:eval (unless (map-elt ement-syncs ement-session)


### PR DESCRIPTION
There are mode line constructs in the mode-name for `ement-room-mode`, so this change works around [Emacs bug#68600](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=68600).

Also declare `visual-line-mode` value in the :options list, as that value is added to this hook as standard.