### PR TITLE
Fix: Non-obvious "Join it, or load link with browser?" prompt

### DIFF
--- a/README.org
+++ b/README.org
@@ -295,7 +295,8 @@ Ement.el doesn't support encrypted rooms natively, but it can be used transparen
 
 ** 0.15-pre
 
-Nothing new yet.
+*Changes*
++ Improve prompt used when viewing a room that is not joined.  ([[https://github.com/alphapapa/ement.el/issues/241][#241]].  Thanks to [[https://github.com/phil-s][Phil Sainty]].)
 
 ** 0.14
 

--- a/ement-lib.el
+++ b/ement-lib.el
@@ -1778,6 +1778,19 @@ seconds, etc."
            (minutes (dividef seconds 60)))
       (list years days hours minutes seconds))))
 
+(defun ement--read-multiple-choice (prompt choices &optional help)
+  "Wrapper for `read-multiple-choice'."
+  ;; Bypasses the hard-coded multi-column formatting in the help buffer
+  ;; (which often doesn't wrap nicely) in favour of one option per line.
+  (let ((help-format (if help
+                         (concat (replace-regexp-in-string "%" "%%" help)
+                                 "\n\n%s")
+                       "%s"))
+        (help-choices (mapconcat (lambda (c)
+                                   (format "%c: %s\n" (car c) (caddr c)))
+                                 choices)))
+    (read-multiple-choice prompt choices (format help-format help-choices))))
+
 ;;; Footer
 
 (provide 'ement-lib)


### PR DESCRIPTION
- Fix #241
- Change: (ement-room-browse-url) Use `read-multiple-choice`.
- Add mouse support (by side-effect).
- Fix: (ement-room-browse-url) Avoid recursive call.
- Add: (ement--read-multiple-choice) Wrapper for `read-multiple-choice` to bypass the hard-coded multi-column formatting in the help buffer (as it tends to wrap poorly).
