### PR TITLE
Fix: (ement--format-body-mentions) Link usernames following newlines

### DIFF
--- a/README.org
+++ b/README.org
@@ -347,6 +347,7 @@ Ement.el doesn't support encrypted rooms natively, but it can be used transparen
 
 *Fixes*
 + Toggling images to fill the window body no longer triggers unintended scrolling.  (Thanks to [[https://github.com/phil-s][Phil Sainty]].)
++ Recognition of mentions after a newline.  ([[https://github.com/alphapapa/ement.el/issues/267][#267]].  Thanks to [[https://github.com/phil-s][Phil Sainty]].)
 
 ** 0.14
 

--- a/ement-lib.el
+++ b/ement-lib.el
@@ -1029,7 +1029,7 @@ period, anywhere in the body."
                          when (equal name (ement--user-displayname-in room user))
                          collect user)))
     (pcase-let* (((cl-struct ement-room members) room)
-                 (regexp (rx (or bos bow (1+ blank))
+                 (regexp (rx (or bos bow blank "\n")
                              (or (seq (group
                                        ;; Group 1: full @-prefixed MXID.
                                        "@" (group


### PR DESCRIPTION
Fixes #267