### PR TITLE
Improvements and bug fixes for the compose buffer enhancements (part 2)

### DIFF
--- a/ement-room.el
+++ b/ement-room.el
@@ -523,9 +523,15 @@ the option `ement-room-compose-buffer-window-auto-height' is
 enabled (this option generally keeps the windows too small to
 usefully display other buffers).
 
-See also `set-window-dedicated-p'."
+The value `delete' means that windows will not be dedicated, but
+they will still be deleted once the message is sent or aborted
+\(even when they have also been used to display other buffers).
+
+See also `set-window-dedicated-p' and
+`switch-to-buffer-in-dedicated-window'."
   :type '(radio (const :tag "Always" t)
                 (const :tag "Never" nil)
+                (const :tag "Never (but always delete window)" delete)
                 (const :tag "Newly-created windows" created)
                 (const :tag "When auto-height enabled" auto-height)))
 
@@ -4587,6 +4593,7 @@ See also `ement-room-compose-buffer-window-state-change-handler'."
         (when (cl-case ement-room-compose-buffer-window-dedicated
                 (created createdp)
                 (auto-height ement-room-compose-buffer-window-auto-height)
+                (delete nil)
                 (t ement-room-compose-buffer-window-dedicated))
           (set-window-dedicated-p win t))))))
 
@@ -4601,6 +4608,9 @@ A non-dedicated window which has displayed another buffer at any
 point will not be deleted."
   ;; N.b. This function exists primarily for documentation purposes,
   ;; to clarify the side-effect of using a dedicated window.
+  (when (eq ement-room-compose-buffer-window-dedicated 'delete)
+    ;; `quit-restore-window' always deletes a dedicated window.
+    (set-window-dedicated-p nil t))
   (quit-restore-window nil 'kill))
 
 (declare-function dabbrev--select-buffers "dabbrev")

--- a/ement-room.el
+++ b/ement-room.el
@@ -500,8 +500,8 @@ sends the composed message directly."
           (reusable-frames . nil)))
   "`display-buffer' action for displaying compose buffers.
 
-See also `ement-room-compose-buffer-window-auto-height' and
-`ement-room-compose-buffer-window-dedicated'."
+See also option `ement-room-compose-buffer-window-auto-height'
+and `ement-room-compose-buffer-window-dedicated'."
   :type display-buffer--action-custom-type
   :risky t)
 
@@ -556,16 +556,16 @@ See also `ement-room-compose-buffer-window-auto-height-max' and
 (defcustom ement-room-compose-buffer-window-auto-height-min nil
   "If non-nil, limits the body height of the compose buffer window.
 
-See also `ement-room-compose-buffer-window-auto-height' and
-`ement-room-compose-buffer-window-auto-height-max'."
+See also option `ement-room-compose-buffer-window-auto-height'
+and `ement-room-compose-buffer-window-auto-height-max'."
   :type '(choice (const :tag "Default" nil)
                  (natnum :tag "Lines")))
 
 (defcustom ement-room-compose-buffer-window-auto-height-max nil
   "If non-nil, limits the body height of the compose buffer window.
 
-See also `ement-room-compose-buffer-window-auto-height' and
-`ement-room-compose-buffer-window-auto-height-min'."
+See also option `ement-room-compose-buffer-window-auto-height'
+and `ement-room-compose-buffer-window-auto-height-min'."
   :type '(choice (const :tag "Default" nil)
                  (natnum :tag "Lines")))
 
@@ -4440,8 +4440,8 @@ a copy of the local keymap, and sets `header-line-format'."
 (defun ement-room-compose-buffer-window-auto-height ()
   "Ensure that the compose buffer displays the whole message.
 
-Called via `post-command-hook' if `ement-room-compose-buffer-window-auto-height'
-is non-nil."
+Called via `post-command-hook' if option
+`ement-room-compose-buffer-window-auto-height' is non-nil."
   ;; We use `post-command-hook' (rather than, say, `after-change-functions'),
   ;; because the required window height might change for reasons other than text
   ;; editing (e.g. changes to the window's width or the font size).

--- a/ement-room.el
+++ b/ement-room.el
@@ -4587,11 +4587,16 @@ See also `ement-room-compose-buffer-window-state-change-handler'."
     ;; created to display a compose buffer.  We set a window property the first
     ;; time that we see the window, so if it's set at all, we've seen it before.
     (unless (assq 'ement-room-compose-buffer-window-created-p (window-parameters win))
-      (let ((createdp (not (window-prev-buffers win))))
-        (set-window-parameter win 'ement-room-compose-buffer-window-created-p
-                              createdp)
+      ;; If the window has never shown any other buffer, then it was created
+      ;; specifically to display a compose buffer.
+      (let ((created-for-compose-p (set-window-parameter
+                                    win 'ement-room-compose-buffer-window-created-p
+                                    (not (window-prev-buffers win)))))
+        ;; Process `ement-room-compose-buffer-window-dedicated' when the compose
+        ;; buffer is first displayed in this window, to decide whether the
+        ;; window should be dedicated to the buffer.
         (when (cl-case ement-room-compose-buffer-window-dedicated
-                (created createdp)
+                (created created-for-compose-p)
                 (auto-height ement-room-compose-buffer-window-auto-height)
                 (delete nil)
                 (t ement-room-compose-buffer-window-dedicated))

--- a/ement-room.el
+++ b/ement-room.el
@@ -4473,8 +4473,15 @@ Called via `post-command-hook' if option
   ;; so a more comprehensive solution, while possible, is not worth the added
   ;; complexity -- our relatively simplistic approach is good enough for the
   ;; vast majority of situations.
+
+  ;; Skip resizing if we are being called recursively...
   (unless (or (bound-and-true-p ement-room-compose-buffer-window-auto-height-resizing-p)
-              (window-full-height-p))
+              ;; ...or there are no other windows to resize...
+              (window-full-height-p)
+              ;; ...or we have just switched to this buffer from another buffer
+              ;; (we may be cycling window buffers, and about to switch again).
+              (and (window-old-buffer)
+                   (not (eq (window-old-buffer) (current-buffer)))))
     ;; Manipulate the window body height.
     (let* ((pixelwise (and ement-room-compose-buffer-window-auto-height-pixelwise
                            (display-graphic-p)))


### PR DESCRIPTION
A handful of bug fixes and enhancements following on from https://github.com/alphapapa/ement.el/pull/270.

* Use a window-parameter for the compose buffer window auto-height cache
  The old system was usually fine in practice, but this is correct/better.

* Prevent unwanted resizing when cycling through buffers in a window
  This eliminates a potential pain point, whereby the window resizing might easily be unwanted.

* Support an option for deleting compose buffer windows without them being dedicated
  This is a way to get the "old" behaviour back (when the windows were not dedicated by default).

* Eliminate the timer-triggered resize from ement-room-compose-buffer-window-buffer-change-handler
  This no longer seemed necessary, so I took the opportunity to simplify things by removing it.

* Improved code comments.
