### PR TITLE
Change: (ement-room-mode) Set `filter-buffer-substring-function'

### DIFF
--- a/README.org
+++ b/README.org
@@ -312,7 +312,8 @@ Ement.el doesn't support encrypted rooms natively, but it can be used transparen
 + Option ~ement-room-coalesce-events~ may now be set to (and defaults to) a maximum number of events to coalesce together.  (This avoids potential performance problems in rare cases.  See [[https://github.com/alphapapa/ement.el/issues/247][#247]].  Thanks to [[https://github.com/viiru-][Arto Jantunen]] for reporting and [[https://github.com/sergiodj][Sergio Durigan Junior]] for testing.)
 
 *Fixes*
-+ Replies to edited messages are correctly sent to the original event (whereas previously they were sent to the edit, which caused reactions to not be shown).  ([[https://github.com/alphapapa/ement.el/issues/230][#230]], [[https://github.com/alphapapa/ement.el/issues/277][#277]].  Thanks to [[https://github.com/phil-s][Phil Sainty]] for suggesting, and to [[https://github.com/dionisos2][dionisos]] for reporting.) 
++ Replies to edited messages are correctly sent to the original event (whereas previously they were sent to the edit, which caused reactions to not be shown).  ([[https://github.com/alphapapa/ement.el/issues/230][#230]], [[https://github.com/alphapapa/ement.el/issues/277][#277]].  Thanks to [[https://github.com/phil-s][Phil Sainty]] for suggesting, and to [[https://github.com/dionisos2][dionisos]] for reporting.)
++ Set ~filter-buffer-substring-function~ in room buffers to prevent undesired text properties from being included in copied text.  ([[https://github.com/alphapapa/ement.el/pull/278][#278]].  Thanks to [[https://github.com/phil-s][Phil Sainty]].)
 
 ** 0.15.1
 

--- a/ement-room.el
+++ b/ement-room.el
@@ -2610,6 +2610,8 @@ and erases the buffer.
         imenu-create-index-function #'ement-room--imenu-create-index-function
         ;; TODO: Use EWOC header/footer for, e.g. typing messages.
         ement-ewoc (ewoc-create #'ement-room--pp-thing))
+  ;; Prevent line/wrap-prefix formatting properties being included in copied text.
+  (setq-local filter-buffer-substring-function #'ement-room--buffer-substring-filter)
   ;; Set the URL handler.  Note that `browse-url-handlers' was added in 28.1;
   ;; prior to that `browse-url-browser-function' served double-duty.
   ;; TODO: Remove compat code when requiring Emacs >=28.
@@ -2800,6 +2802,18 @@ data slot."
   "Return STRING with \"%\" escaped.
 Needed to display things in the header line."
   (replace-regexp-in-string (rx "%") "%%" string t t))
+
+(defun ement-room--buffer-substring-filter (beg end &optional delete)
+  "Value for `filter-buffer-substring-function' in Ement rooms.
+
+Strips the `line-prefix' and `wrap-prefix' text properties which
+are used when formatting certain Matrix events, but which should
+not be copied into other buffers."
+  (let ((string (funcall (default-value 'filter-buffer-substring-function)
+                         beg end delete)))
+    (remove-list-of-text-properties
+     0 (length string) '(line-prefix wrap-prefix) string)
+    string))
 
 ;;;;; Imenu
 


### PR DESCRIPTION
Strip the `line-prefix` and `wrap-prefix` text properties which are used when formatting certain Matrix events, but which should not be copied into other buffers.

This is especially relevant when using `%W` in `ement-room-message-format-spec` to provide indentation when wrapping message body lines.

With this filter configured, we can copy text from an ement room and yank it into another buffer without this formatting being included.  See also `filter-buffer-substring`:

> For example, major or minor modes can use `filter-buffer-substring-function' to exclude text properties that are special to a buffer, and should not be copied into other buffers.
