### PR TITLE
Opening buffers whose rooms have very large numbers of adjacent membership events can be very slow

### DIFF
--- a/README.org
+++ b/README.org
@@ -299,7 +299,9 @@ Ement.el doesn't support encrypted rooms natively, but it can be used transparen
 
 ** 0.16-pre
 
-Nothing new yet.
+*Changes*
+
++ Option ~ement-room-coalesce-events~ may now be set to (and defaults to) a maximum number of events to coalesce together.  (This avoids potential performance problems in rare cases.  See [[https://github.com/alphapapa/ement.el/issues/247][#247]].  Thanks to [[https://github.com/viiru-][Arto Jantunen]] for reporting and [[https://github.com/sergiodj][Sergio Durigan Junior]] for testing.)
 
 ** 0.15.1
 


### PR DESCRIPTION
### OS/platform

Debian testing

### Emacs version and provenance

29.1, installed as a package from Debian testing.

### Emacs command

emacs --fg-daemon

### Emacs frame type

Gui frame, pgtk

### Ement package version and provenance

0.13, as a package from Debian testing

### Actions taken

Pressed enter in the room list buffer to open a room buffer

### Observed results

It took slightly over 7 minutes (with Emacs using 100% cpu for the whole time) to open the buffer for a room with 221 members. The room is bridged to IRC, so it sees a lot of joining and leaving (I assume processing these is the problem).

### Expected results

Most rooms only take a few seconds to open. Getting below a minute would already be quite useful.

### Backtrace

_No response_

### Etc.

Adding a per-room or global option to not process all of the membership changes at buffer open time would be a workaround.

I wonder if this is actually necessary at all, though. If I press C-g while this is happening the buffer opens just fine, it just doesn't contain the list of members at the top.