### PR TITLE
Fix: Customize group for ement-room-mode-hook, ement-room-self-insert-mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -317,6 +317,7 @@ Ement.el doesn't support encrypted rooms natively, but it can be used transparen
 + Command ~ement-disconnect~ no longer shows an error message.  ([[https://github.com/alphapapa/ement.el/issues/208][#208]].)
 + Retrieval of earlier events in a just-joined room.  ([[https://github.com/alphapapa/ement.el/issues/148][#148]].  Thanks to [[https://github.com/MagicRB][Richard Brežák]] for reporting, and to [[https://github.com/phil-s][Phil Sainty]] for testing.)
 + Cache computed displaynames in rooms (avoiding unnecessary reiteration and recalculation).  ([[https://github.com/alphapapa/ement.el/issues/298][#298]].  Thanks to [[https://github.com/Rutherther][Rutherther]] for reporting and testing, and to [[https://github.com/phil-s][Phil Sainty]].)
++ Customization group for options ~ement-room-mode-hook~ and ~ement-room-self-insert-mode~.  (Thanks to [[https://github.com/phil-s][Phil Sainty]].)  
 
 ** 0.15.1
 

--- a/ement-room.el
+++ b/ement-room.el
@@ -2601,7 +2601,8 @@ the previously oldest event."
   ;; into the auto-generated docstring.
   "Hook run after entering `ement-room-mode'."
   :options '(visual-line-mode)
-  :type 'hook)
+  :type 'hook
+  :group 'ement-room)
 
 (define-derived-mode ement-room-mode fundamental-mode
   `("Ement-Room"
@@ -2672,6 +2673,7 @@ via `ement-room-mode-self-insert-keymap-update-hook' (see which)."
   :init-value nil
   :global t
   :keymap nil
+  :group 'ement-room
   ;; Ensure the self-insert and advertised keymaps are up to date.
   (if ement-room-self-insert-mode
       (ement-room-mode-self-insert-keymap-update)


### PR DESCRIPTION
These definitions come after defgroup ement-room-prism, so they need an explicit :group argument.