### PR TITLE
Add: global minor mode `ement-sync-watchdog-mode'

### DIFF
--- a/README.org
+++ b/README.org
@@ -299,6 +299,12 @@ Ement.el doesn't support encrypted rooms natively, but it can be used transparen
 
 ** 0.16-pre
 
+*Additions*
+
++ Global minor mode ~ement-sync-watchdog-mode~ periodically re-syncs sessions in case of ~ement-auto-sync~ failures.  Customizing ~ement-auto-sync~ automatically enables/disables the new mode.  (Thanks to [[https://github.com/phil-s][Phil Sainty]].)
+  - Option ~ement-sync-watchdog-interval~ determines how frequently the global mode acts (by default, every 5 minutes).
+  - Option ~ement-sync-watchdog-sessions~ allows you to constrain which sessions are targeted (by default, all sessions).
+
 *Changes*
 
 + Option ~ement-room-coalesce-events~ may now be set to (and defaults to) a maximum number of events to coalesce together.  (This avoids potential performance problems in rare cases.  See [[https://github.com/alphapapa/ement.el/issues/247][#247]].  Thanks to [[https://github.com/viiru-][Arto Jantunen]] for reporting and [[https://github.com/sergiodj][Sergio Durigan Junior]] for testing.)

--- a/ement.el
+++ b/ement.el
@@ -89,6 +89,9 @@
 Hooks are called with one argument, the session that was
 synced.")
 
+(defvar ement-sync-watchdog-timer nil
+  "Timer used by `ement-sync-watchdog-mode'.")
+
 (defvar ement-event-hook
   '(ement-notify ement--process-event ement--put-event)
   "Hook called for events.
@@ -136,7 +139,14 @@ Writes the session file when Emacs is killed."
   :type 'file)
 
 (defcustom ement-auto-sync t
-  "Automatically sync again after syncing."
+  "Automatically sync again after syncing.
+
+Customizing this option also enables or disables
+`ement-sync-watchdog-mode'."
+  :set (lambda (option value)
+         (set-default-toplevel-value option value)
+         (when (fboundp 'ement-sync-watchdog-mode)
+           (ement-sync-watchdog-mode (if value 1 0))))
   :type 'boolean)
 
 (defcustom ement-after-initial-sync-hook
@@ -157,6 +167,19 @@ might be necessary."
 Alist mapping user IDs to a list of room aliases/IDs to open buffers for."
   :type '(alist :key-type (string :tag "Local user ID")
                 :value-type (repeat (string :tag "Room alias/ID"))))
+
+(defcustom ement-sync-watchdog-interval 300
+  "The interval in seconds for `ement-sync-watchdog-mode'."
+  :type 'integer)
+
+(defcustom ement-sync-watchdog-sessions t
+  "Sessions for `ement-sync-watchdog-mode' to watch.
+
+Either t, meaning \"all known sessions\", or a list of User ID
+strings of the form @USERNAME:SERVER to identify which sessions
+should be automatically re-sync'd by this mode."
+  :type '(choice (const :tag "All sessions" t)
+                 (repeat :tag "User ID list" string)))
 
 (defcustom ement-disconnect-hook '(ement-kill-buffers ement--stop-idle-timer)
   ;; FIXME: Put private functions in a private hook.
@@ -389,6 +412,28 @@ Useful in, e.g. `ement-disconnect-hook', which see."
           (alist-get user-id ement-sessions nil nil #'equal) session)
     (ement--sync session :timeout ement-initial-sync-timeout)))
 
+(define-minor-mode ement-sync-watchdog-mode
+  "Periodically re-sync sessions as a `ement-auto-sync' failsafe.
+
+Calls function `ement-sync-watchdog-sessions' every
+`ement-sync-watchdog-interval' seconds.
+
+Customizing `ement-auto-sync' also enables/disables this mode."
+  :global t
+  :init-value nil
+  :lighter ""
+  (when (and ement-sync-watchdog-timer
+	     (timerp ement-sync-watchdog-timer))
+    (cancel-timer ement-sync-watchdog-timer)
+    (setq ement-sync-watchdog-timer nil))
+  (when ement-sync-watchdog-mode
+    (setq ement-sync-watchdog-timer
+	  (run-at-time t ement-sync-watchdog-interval
+		       #'ement-sync-watchdog-sessions))))
+
+;; Enable the mode if `ement-auto-sync' is also enabled.
+(ement-sync-watchdog-mode (if ement-auto-sync 1 0))
+
 ;;;; Functions
 
 (defun ement-interrupted-sync-warning (session)
@@ -407,6 +452,23 @@ Useful in, e.g. `ement-disconnect-hook', which see."
    (substitute-command-keys
     "\\<ement-room-mode-map>Syncing of session <%s> was interrupted.  Use command `ement-room-sync' in a room buffer to retry.")
    (ement-user-id (ement-session-user session))))
+
+(defun ement-sync-watchdog-sessions ()
+  "Re-sync known sessions.
+
+Called every `ement-sync-watchdog-interval' seconds when
+`ement-sync-watchdog-mode' is enabled.
+
+Syncs all sessions by default.  To constrain it to a limited set,
+customize option `ement-sync-watchdog-sessions'."
+  (let ((sessions (if (eq ement-sync-watchdog-sessions t)
+                      ement-sessions
+                    (delq nil (mapcar (lambda (id)
+                                        (assoc id ement-sessions))
+                                      ement-sync-watchdog-sessions)))))
+    (cl-loop for (_id . session) in sessions
+             do (ignore-errors
+                  (ement--sync session)))))
 
 (defun ement--run-idle-timer (&rest _ignore)
   "Run idle timer that updates read receipts.


### PR DESCRIPTION
Global minor mode `ement-sync-watchdog-mode` periodically re-syncs sessions in case of `ement-auto-sync` failures.  Customizing `ement-auto-sync` automatically enables/disables the new mode.

Option `ement-sync-watchdog-interval` determines how frequently the global mode acts (by default, every 5 minutes).

Option `ement-sync-watchdog-sessions` allows you to constrain which sessions are targeted (by default, all sessions).

Closes #177.
