### PR TITLE
Fix: Fix inheritance in face definitions

### DIFF
--- a/ement-room-list.el
+++ b/ement-room-list.el
@@ -162,7 +162,7 @@ Set automatically when `ement-room-list-mode' is activated.")
   "Favourite rooms.")
 
 (defface ement-room-list-invited
-  '((t (:inherit italic ement-room-list-name)))
+  '((t (:inherit (italic ement-room-list-name))))
   "Invited rooms.")
 
 (defface ement-room-list-left
@@ -173,7 +173,7 @@ Set automatically when `ement-room-list-mode' is activated.")
   "Low-priority rooms.")
 
 (defface ement-room-list-name
-  '((t (:inherit font-lock-function-name-face button)))
+  '((t (:inherit (font-lock-function-name-face button))))
   "Non-direct rooms.")
 
 (defface ement-room-list-space '((t (:inherit (font-lock-regexp-grouping-backslash ement-room-list-name))))
@@ -181,7 +181,7 @@ Set automatically when `ement-room-list-mode' is activated.")
   :group 'ement-room-list)
 
 (defface ement-room-list-unread
-  '((t (:inherit bold ement-room-list-name)))
+  '((t (:inherit (bold ement-room-list-name))))
   "Unread rooms.")
 
 (defface ement-room-list-recent '((t (:inherit font-lock-warning-face)))

--- a/ement-tabulated-room-list.el
+++ b/ement-tabulated-room-list.el
@@ -89,7 +89,7 @@ For example, \"1h54m3s\" becomes \"1h\"."
 ;;;;; Faces
 
 (defface ement-tabulated-room-list-name
-  '((t (:inherit font-lock-function-name-face button)))
+  '((t (:inherit (font-lock-function-name-face button))))
   "Non-direct rooms.")
 
 (defface ement-tabulated-room-list-direct
@@ -99,7 +99,7 @@ For example, \"1h54m3s\" becomes \"1h\"."
   "Direct rooms.")
 
 (defface ement-tabulated-room-list-invited
-  '((t (:inherit italic ement-tabulated-room-list-name)))
+  '((t (:inherit (italic ement-tabulated-room-list-name))))
   "Invited rooms.")
 
 (defface ement-tabulated-room-list-left
@@ -107,7 +107,7 @@ For example, \"1h54m3s\" becomes \"1h\"."
   "Left rooms.")
 
 (defface ement-tabulated-room-list-unread
-  '((t (:inherit bold ement-tabulated-room-list-name)))
+  '((t (:inherit (bold ement-tabulated-room-list-name))))
   "Unread rooms.")
 
 (defface ement-tabulated-room-list-favourite '((t (:inherit (font-lock-doc-face ement-tabulated-room-list-name))))


### PR DESCRIPTION
The byte-compiler of Emacs 31 has started to warn about these.