### PR TITLE
Fix: (ement-room--event-body-face) variable-pitch face consistency

### DIFF
--- a/README.org
+++ b/README.org
@@ -317,7 +317,8 @@ Ement.el doesn't support encrypted rooms natively, but it can be used transparen
 + Command ~ement-disconnect~ no longer shows an error message.  ([[https://github.com/alphapapa/ement.el/issues/208][#208]].)
 + Retrieval of earlier events in a just-joined room.  ([[https://github.com/alphapapa/ement.el/issues/148][#148]].  Thanks to [[https://github.com/MagicRB][Richard Brežák]] for reporting, and to [[https://github.com/phil-s][Phil Sainty]] for testing.)
 + Cache computed displaynames in rooms (avoiding unnecessary reiteration and recalculation).  ([[https://github.com/alphapapa/ement.el/issues/298][#298]].  Thanks to [[https://github.com/Rutherther][Rutherther]] for reporting and testing, and to [[https://github.com/phil-s][Phil Sainty]].)
-+ Customization group for options ~ement-room-mode-hook~ and ~ement-room-self-insert-mode~.  (Thanks to [[https://github.com/phil-s][Phil Sainty]].)  
++ Customization group for options ~ement-room-mode-hook~ and ~ement-room-self-insert-mode~.  (Thanks to [[https://github.com/phil-s][Phil Sainty]].)
++ Improved face consistency when ~ement-use-variable-pitch~ is enabled.  (Thanks to [[https://github.com/phil-s][Phil Sainty]].)
 
 ** 0.15.1
 

--- a/ement-room.el
+++ b/ement-room.el
@@ -1409,7 +1409,10 @@ shr.el used the `variable-pitch' face directly.")
                                          (not (equal (or format (alist-get 'format new-content))
                                                      "org.matrix.custom.html")))
                                 ement-room-variable-pitch-face))
-               (body-face (list :inherit (delq nil (list redacted-face context-face type-face shr-text-face)))))
+               (base-body-face (list :inherit (delq nil (list redacted-face context-face type-face))))
+               (body-face (if shr-text-face
+                              (list shr-text-face base-body-face)
+                            base-body-face)))
     (if prism-color
         (plist-put body-face :foreground prism-color)
       body-face)))


### PR DESCRIPTION
For HTML messages we end up with face specs such as:

 (shr-text (:inherit (ement-room-mention ement-room-message-text)))

However for plain text messages, with `ement-use-variable-pitch' enabled, we ended up with a different arrangement:

 (:inherit (ement-room-mention ement-room-message-text shr-text))

That could produce some rendering inconsistencies, so this change ensures the plain text face spec matches the HTML spec exactly when `ement-use-variable-pitch' is enabled.