### PR TITLE
Add: Custom message format spec for notification buffers

### DIFF
--- a/README.org
+++ b/README.org
@@ -306,6 +306,7 @@ Ement.el doesn't support encrypted rooms natively, but it can be used transparen
 *Additions*
 
 + When option ~ement-room-images~ is disabled (preventing automatic download and display of images), individual images may be shown by clicking the button in their events.
++ New options ~ement-notifications-message-format-spec~ and ~ement-notifications-room-button-separator~ allow the notification buffer message rendering to be customised.  (Thanks to [[https://github.com/phil-s][Phil Sainty]].)
 
 *Changes*
 

--- a/ement-room.el
+++ b/ement-room.el
@@ -859,6 +859,7 @@ non-nil, set the variables buffer-locally (i.e. when called from
         (message "Ement: Kill and reopen room buffers to display in new format")))))
 
 (defcustom ement-room-message-format-spec "%S%L%B%r%R%t"
+  ;; Formatter definitions: (occur "(\\ement-room-define-event-formatter")
   "Format messages according to this spec.
 It may contain these specifiers:
 
@@ -878,7 +879,9 @@ It may contain these specifiers:
 
 Note that margin sizes must be set manually with
 `ement-room-left-margin-width' and
-`ement-room-right-margin-width'."
+`ement-room-right-margin-width'.
+
+See also `ement-notifications-message-format-spec'."
   :type '(choice (const :tag "IRC-style using margins" "%S%L%B%r%R%t")
                  (const :tag "IRC-style without margins" "[%t] %S> %B%r")
                  (const :tag "IRC-style without margins, with wrap-prefix" "[%t] %S> %W%B%r")
@@ -4000,6 +4003,8 @@ Formats according to `ement-room-message-format-spec', which see."
 (cl-defun ement-room--format-message (event room session &optional (format ement-room-message-format-spec))
   "Return EVENT in ROOM on SESSION formatted according to FORMAT.
 Format defaults to `ement-room-message-format-spec', which see."
+  ;; Formatter definitions: (occur "(\\ement-room-define-event-formatter")
+  ;;
   ;; Bind this locally so formatters can modify it for this call.
   (let ((ement-room--format-message-margin-p)
         (left-margin-width ement-room-left-margin-width)


### PR DESCRIPTION
- `ement-notifications-message-format-spec`: New user option.
- `ement-notifications-room-button-separator`: New user option.
- `ement-notifications-log-to-buffer`: Use them.
