### PR TITLE
Add: Customize groups for Ement faces

### DIFF
--- a/README.org
+++ b/README.org
@@ -297,6 +297,10 @@ Ement.el doesn't support encrypted rooms natively, but it can be used transparen
 :TOC:      :depth 0
 :END:
 
+** 0.17-pre
+
+Nothing new yet.
+
 ** 0.16
 
 *Compatibility*

--- a/README.org
+++ b/README.org
@@ -299,7 +299,9 @@ Ement.el doesn't support encrypted rooms natively, but it can be used transparen
 
 ** 0.17-pre
 
-Nothing new yet.
+*Additions*
+
++ Customization groups for faces.  (Thanks to [[https://github.com/phil-s][Phil Sainty]].)
 
 ** 0.16
 

--- a/ement-room-list.el
+++ b/ement-room-list.el
@@ -35,10 +35,6 @@
 
 (require 'ement-lib)
 
-(defgroup ement-room-list nil
-  "Group Ement rooms with Taxy."
-  :group 'ement)
-
 ;;;; Mouse commands
 
 ;; Since mouse-activated commands must handle mouse events, we define a simple macro to
@@ -127,6 +123,11 @@ Set automatically when `ement-room-list-mode' is activated.")
 
 ;;;; Customization
 
+(defgroup ement-room-list-faces nil
+  "Faces for room list buffers."
+  :group 'ement-room-list
+  :group 'ement-faces)
+
 (defgroup ement-room-list nil
   "Options for room list buffers."
   :group 'ement)
@@ -156,44 +157,53 @@ Set automatically when `ement-room-list-mode' is activated.")
     (copy-face 'font-lock-constant-face 'ement--font-lock-constant-face)
     (set-face-attribute 'ement--font-lock-constant-face nil :weight 'unspecified)
     '((t (:inherit (ement--font-lock-constant-face ement-room-list-name)))))
-  "Direct rooms.")
+  "Direct rooms."
+  :group 'ement-room-list-faces)
 
 (defface ement-room-list-favourite '((t (:inherit (font-lock-doc-face ement-room-list-name))))
-  "Favourite rooms.")
+  "Favourite rooms."
+  :group 'ement-room-list-faces)
 
 (defface ement-room-list-invited
   '((t (:inherit (italic ement-room-list-name))))
-  "Invited rooms.")
+  "Invited rooms."
+  :group 'ement-room-list-faces)
 
 (defface ement-room-list-left
   '((t (:strike-through t :inherit ement-room-list-name)))
-  "Left rooms.")
+  "Left rooms."
+  :group 'ement-room-list-faces)
 
 (defface ement-room-list-low-priority '((t (:inherit (font-lock-comment-face ement-room-list-name))))
-  "Low-priority rooms.")
+  "Low-priority rooms."
+  :group 'ement-room-list-faces)
 
 (defface ement-room-list-name
   '((t (:inherit (font-lock-function-name-face button))))
-  "Non-direct rooms.")
+  "Non-direct rooms."
+  :group 'ement-room-list-faces)
 
 (defface ement-room-list-space '((t (:inherit (font-lock-regexp-grouping-backslash ement-room-list-name))))
   "Space rooms."
-  :group 'ement-room-list)
+  :group 'ement-room-list-faces)
 
 (defface ement-room-list-unread
   '((t (:inherit (bold ement-room-list-name))))
-  "Unread rooms.")
+  "Unread rooms."
+  :group 'ement-room-list-faces)
 
 (defface ement-room-list-recent '((t (:inherit font-lock-warning-face)))
   "Latest timestamp of recently updated rooms.
 The foreground color is used to generate a gradient of colors
 from recent to non-recent for rooms updated in the past 24
-hours but at least one hour ago.")
+hours but at least one hour ago."
+  :group 'ement-room-list-faces)
 
 (defface ement-room-list-very-recent '((t (:inherit error)))
   "Latest timestamp of very recently updated rooms.
 The foreground color is used to generate a gradient of colors
-from recent to non-recent for rooms updated in the past hour.")
+from recent to non-recent for rooms updated in the past hour."
+  :group 'ement-room-list-faces)
 
 ;;;; Keys
 

--- a/ement-room.el
+++ b/ement-room.el
@@ -309,6 +309,11 @@ Does not include filenames, emotes, etc.")
 
 ;;;; Customization
 
+(defgroup ement-room-faces nil
+  "Faces for room buffers."
+  :group 'ement-room
+  :group 'ement-faces)
+
 (defgroup ement-room nil
   "Options for room buffers."
   :group 'ement)
@@ -335,73 +340,88 @@ number of senders instead (and the names in a tooltip)."
 
 (defface ement-room-name
   '((t (:inherit font-lock-function-name-face)))
-  "Room name shown in header line.")
+  "Room name shown in header line."
+  :group 'ement-room-faces)
 
 (defface ement-room-membership
   '((t (:height 0.8 :inherit font-lock-comment-face)))
-  "Membership events (join/part).")
+  "Membership events (join/part)."
+  :group 'ement-room-faces)
 
 (defface ement-room-reactions
   '((t (:inherit font-lock-comment-face :height 0.9)))
-  "Reactions to messages (including the user count).")
+  "Reactions to messages (including the user count)."
+  :group 'ement-room-faces)
 
 (defface ement-room-reactions-key
   '((t (:inherit ement-room-reactions :height 1.5)))
   "Reactions to messages (the key, i.e. the emoji part).
 Uses a separate face to allow the key to be shown at a different
 size, because in some fonts, emojis are too small relative to
-normal text.")
+normal text."
+  :group 'ement-room-faces)
 
 (defface ement-room-timestamp
   '((t (:inherit font-lock-comment-face)))
-  "Event timestamps.")
+  "Event timestamps."
+  :group 'ement-room-faces)
 
 (defface ement-room-user
   '((t (:inherit font-lock-function-name-face :weight bold :overline t)))
-  "Usernames.")
+  "Usernames."
+  :group 'ement-room-faces)
 
 (defface ement-room-self
   '((t (:inherit (font-lock-variable-name-face ement-room-user) :weight bold)))
-  "Own username.")
+  "Own username."
+  :group 'ement-room-faces)
 
 (defface ement-room-message-text
   '((t (:inherit default)))
-  "Text message bodies.")
+  "Text message bodies."
+  :group 'ement-room-faces)
 
 (defface ement-room-message-emote
   '((t (:inherit italic)))
-  "Emote message bodies.")
+  "Emote message bodies."
+  :group 'ement-room-faces)
 
 (defface ement-room-quote
   '((t (:height 0.9 :inherit font-lock-comment-face)))
   "Quoted parts of messages.
-Anything wrapped by HTML BLOCKQUOTE tag.")
+Anything wrapped by HTML BLOCKQUOTE tag."
+  :group 'ement-room-faces)
 
 (defface ement-room-redacted
   '((t (:strike-through t)))
-  "Redacted messages.")
+  "Redacted messages."
+  :group 'ement-room-faces)
 
 (defface ement-room-self-message
   '((t (:inherit (font-lock-variable-name-face))))
   "Oneself's message bodies.
 Note that this does not need to inherit
 `ement-room-message-text', because that face is combined with
-this one automatically.")
+this one automatically."
+  :group 'ement-room-faces)
 
 (defface ement-room-timestamp-header
   '((t (:inherit header-line :weight bold :height 1.1)))
-  "Timestamp headers.")
+  "Timestamp headers."
+  :group 'ement-room-faces)
 
 (defface ement-room-mention
   ;; TODO(30.1): Remove when not supporting Emacs 27 anymore.
   (if (version< emacs-version "27.1")
       '((t (:inherit hl-line)))
     '((t (:inherit hl-line :extend t))))
-  "Messages that mention the local user.")
+  "Messages that mention the local user."
+  :group 'ement-room-faces)
 
 (defface ement-room-wrap-prefix
   `((t :inherit highlight))
-  "Face applied to `ement-room-wrap-prefix', which see.")
+  "Face applied to `ement-room-wrap-prefix', which see."
+  :group 'ement-room-faces)
 
 ;;;;; Options
 
@@ -3237,12 +3257,12 @@ function to `ement-room-event-fns', which see."
 (defface ement-room-read-receipt-marker
   '((t (:inherit show-paren-match)))
   "Read marker line in rooms."
-  :group 'ement-room)
+  :group 'ement-room-faces)
 
 (defface ement-room-fully-read-marker
   '((t (:inherit isearch)))
   "Fully read marker line in rooms."
-  :group 'ement-room)
+  :group 'ement-room-faces)
 
 (defcustom ement-room-send-read-receipts t
   "Whether to send read receipts.

--- a/ement-tabulated-room-list.el
+++ b/ement-tabulated-room-list.el
@@ -69,8 +69,13 @@ Set automatically when `ement-tabulated-room-list-mode' is activated.")
 
 ;;;; Customization
 
+(defgroup ement-tabulated-room-list-faces nil
+  "Faces for tabulated room list buffers."
+  :group 'ement-tabulated-room-list
+  :group 'ement-faces)
+
 (defgroup ement-tabulated-room-list nil
-  "Options for the room list buffer."
+  "Options for tabulated room list buffers."
   :group 'ement)
 
 (defcustom ement-tabulated-room-list-auto-update t
@@ -90,44 +95,53 @@ For example, \"1h54m3s\" becomes \"1h\"."
 
 (defface ement-tabulated-room-list-name
   '((t (:inherit (font-lock-function-name-face button))))
-  "Non-direct rooms.")
+  "Non-direct rooms."
+  :group 'ement-tabulated-room-list-faces)
 
 (defface ement-tabulated-room-list-direct
   ;; In case `font-lock-constant-face' is bold, we set the weight to normal, so it can be
   ;; made bold for unread rooms only.
   '((t (:weight normal :inherit (font-lock-constant-face ement-tabulated-room-list-name))))
-  "Direct rooms.")
+  "Direct rooms."
+  :group 'ement-tabulated-room-list-faces)
 
 (defface ement-tabulated-room-list-invited
   '((t (:inherit (italic ement-tabulated-room-list-name))))
-  "Invited rooms.")
+  "Invited rooms."
+  :group 'ement-tabulated-room-list-faces)
 
 (defface ement-tabulated-room-list-left
   '((t (:strike-through t :inherit ement-tabulated-room-list-name)))
-  "Left rooms.")
+  "Left rooms."
+  :group 'ement-tabulated-room-list-faces)
 
 (defface ement-tabulated-room-list-unread
   '((t (:inherit (bold ement-tabulated-room-list-name))))
-  "Unread rooms.")
+  "Unread rooms."
+  :group 'ement-tabulated-room-list-faces)
 
 (defface ement-tabulated-room-list-favourite '((t (:inherit (font-lock-doc-face ement-tabulated-room-list-name))))
-  "Favourite rooms.")
+  "Favourite rooms."
+  :group 'ement-tabulated-room-list-faces)
 
 (defface ement-tabulated-room-list-low-priority '((t (:inherit (font-lock-comment-face ement-tabulated-room-list-name))))
-  "Low-priority rooms.")
+  "Low-priority rooms."
+  :group 'ement-tabulated-room-list-faces)
 
 (defface ement-tabulated-room-list-recent
   '((t (:inherit font-lock-warning-face)))
   "Latest timestamp of recently updated rooms.
 The foreground color is used to generate a gradient of colors
 from recent to non-recent for rooms updated in the past 24
-hours but at least one hour ago.")
+hours but at least one hour ago."
+  :group 'ement-tabulated-room-list-faces)
 
 (defface ement-tabulated-room-list-very-recent
   '((t (:inherit error)))
   "Latest timestamp of very recently updated rooms.
 The foreground color is used to generate a gradient of colors
-from recent to non-recent for rooms updated in the past hour.")
+from recent to non-recent for rooms updated in the past hour."
+  :group 'ement-tabulated-room-list-faces)
 
 ;;;; Bookmark support
 

--- a/ement.el
+++ b/ement.el
@@ -5,7 +5,7 @@
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; Maintainer: Adam Porter <adam@alphapapa.net>
 ;; URL: https://github.com/alphapapa/ement.el
-;; Version: 0.16
+;; Version: 0.17-pre
 ;; Package-Requires: ((emacs "27.1") (map "2.1") (persist "0.5") (plz "0.6") (taxy "0.10") (taxy-magit-section "0.13") (svg-lib "0.2.5") (transient "0.3.7"))
 ;; Keywords: comm
 

--- a/ement.el
+++ b/ement.el
@@ -116,6 +116,10 @@ by users; ones who do so should know what they're doing.")
 
 ;;;; Customization
 
+(defgroup ement-faces nil
+  "Faces for Ement."
+  :group 'ement)
+
 (defgroup ement nil
   "Options for Ement, the Matrix client."
   :group 'comm)


### PR DESCRIPTION
Each face now belongs to one of the following new groups:

- `ement-room-faces` (sub-group of `ement-room`)
- `ement-room-list-faces` (sub-group of `ement-room-list`)
- `ement-tabulated-room-list-faces` (sub-group of `ement-tabulated-room-list`)

Additionally, each of those new groups is also a sub-group of another new group `ement-faces` (which is parent to only the three 'faces' sub-groups).

You can therefore navigate to each list of faces from either the customize group the faces used to belong to, or via the new `ement-faces` container.

Also:

- Delete duplicate defgroup ement-room-list.
- Tweak phrasing for defgroup ement-tabulated-room-list for consistency with ement-room-list.
