### PR TITLE
Support downloading media

### DIFF
--- a/README.org
+++ b/README.org
@@ -301,6 +301,7 @@ Ement.el doesn't support encrypted rooms natively, but it can be used transparen
 
 *Additions*
 
++ Command ~ement-room-download-file~, which downloads the file in the event at point (for image, audio, video, and file messages).  ([[https://github.com/alphapapa/ement.el/pull/323][#323]].  Thanks to [[https://github.com/viiru-][Arto Jantunen]].)
 + Customization groups for faces.  (Thanks to [[https://github.com/phil-s][Phil Sainty]].)
 + Option ~ement-room-hide-redacted-message-content~, which hides the content of redacted messages by default.  It may be disabled to keep redacted content visible with a strikethrough face, which may be useful for room moderators, but users should keep in mind that doing so will leave unpleasant content visible in the current session, even after being redacted by moderators.
 + Option ~ement-room-list-avatars-generation~: if disabled, SVG-based room avatars are not generated.  This option automatically tests whether SVG support is available in Emacs, and should allow use with builds of Emacs that lack =librsvg= support. 
@@ -308,6 +309,10 @@ Ement.el doesn't support encrypted rooms natively, but it can be used transparen
 *Changes*
 
 + Disable underline for faces ~ement-room-list-direct~ and ~ement-room-list-name~ (in case a face they inherit from enables it, e.g. when themed).
+
+*Fixes*
+
++ Call ~eww-browse-url~ instead of ~browse-url~ in ~ement-room-browse-mxc~ (because the latter is not useful for authenticated media if the user has configured it to use a different browser).  ([[https://github.com/alphapapa/ement.el/pull/323][#323]].  Thanks to [[https://github.com/viiru-][Arto Jantunen]].)
 
 ** 0.16
 

--- a/ement-room.el
+++ b/ement-room.el
@@ -5546,9 +5546,9 @@ Then invalidate EVENT's node to show the image."
                              (file-size-human-readable size)))
                (string (format "[file: %s (%s) (%s)]" filename mimetype human-size)))
     (concat (propertize string
-                        'action #'ement-room-browse-mxc
+                        'action #'ement-room-download-event-file
                         'button t
-                        'button-data mxc-url
+                        'button-data event
                         'category t
                         'face 'button
                         'follow-link t
@@ -5569,9 +5569,9 @@ Then invalidate EVENT's node to show the image."
                (human-size (file-size-human-readable size))
                (string (format "[video: %s (%s) (%sx%s) (%s)]" body mimetype w h human-size)))
     (concat (propertize string
-                        'action #'ement-room-browse-mxc
+                        'action #'ement-room-download-event-file
                         'button t
-                        'button-data mxc-url
+                        'button-data event
                         'category t
                         'face 'button
                         'follow-link t
@@ -5592,9 +5592,9 @@ Then invalidate EVENT's node to show the image."
                (human-duration (format-seconds "%m:%s" (/ duration 1000)))
                (string (format "[audio: %s (%s) (%s) (%s)]" body mimetype human-duration human-size)))
     (concat (propertize string
-                        'action #'ement-room-browse-mxc
+                        'action #'ement-room-download-event-file
                         'button t
-                        'button-data mxc-url
+                        'button-data event
                         'category t
                         'face 'button
                         'follow-link t

--- a/ement-room.el
+++ b/ement-room.el
@@ -5935,6 +5935,21 @@ For use in `completion-at-point-functions'."
                          (apply callback 'status cbargs))))))
       (eww-browse-url mxc))))
 
+;;;; Downloading media/files
+
+(defun ement-room-download-event-file (event)
+  (pcase-let* (((cl-struct ement-event
+                           (content (map ('filename event-filename)
+                                         ('url mxc-url))))
+                event))
+               (let* ((session ement-session)
+                     (dir (if (stringp eww-download-directory)
+                              eww-download-directory
+                            (funcall eww-download-directory)))
+                     (filename (expand-file-name (file-name-nondirectory event-filename) dir)))
+                 (access-file dir "Download failed")
+                 (ement--media-request mxc-url session :as (list 'file filename)))))
+
 ;;;; Footer
 
 (provide 'ement-room)

--- a/ement-room.el
+++ b/ement-room.el
@@ -5933,7 +5933,7 @@ For use in `completion-at-point-functions'."
                          (decode-coding-region (point-min) (point) 'utf-8)
                          ;; HACK: This STATUS argument to `eww-render' is bogus.
                          (apply callback 'status cbargs))))))
-      (browse-url mxc))))
+      (eww-browse-url mxc))))
 
 ;;;; Footer
 

--- a/ement-room.el
+++ b/ement-room.el
@@ -5946,7 +5946,7 @@ For use in `completion-at-point-functions'."
                      (dir (if (stringp eww-download-directory)
                               eww-download-directory
                             (funcall eww-download-directory)))
-                     (filename (expand-file-name (file-name-nondirectory event-filename) dir)))
+                     (filename (expand-file-name(read-file-name "Download to: " (file-name-concat dir (file-name-nondirectory event-filename))))))
                  (access-file dir "Download failed")
                  (ement--media-request mxc-url session :as (list 'file filename)))))
 

--- a/ement-room.el
+++ b/ement-room.el
@@ -5980,6 +5980,9 @@ otherwise, download to the filename.  Interactively, download to
       (user-error "Destination path not writable: %S" destination))
     (when (file-exists-p destination)
       (user-error "File already exists: %S" destination))
+    ;; TODO: For bonus points, provide a way to cancel a download (otherwise the user
+    ;; would have to use `list-processes' and find the right one to delete), and to see
+    ;; progress (perhaps borrowing some of the relevant code in hyperdrive.el).
     (ement--media-request mxc-url ement-session :authenticatedp t
       :as `(file ,destination)
       :then (lambda (&rest _)

--- a/ement-room.el
+++ b/ement-room.el
@@ -195,6 +195,7 @@ keymap directly the issue may be visible.")
     (define-key map (kbd "s f") #'ement-room-send-file)
     (define-key map (kbd "s i") #'ement-room-send-image)
     (define-key map (kbd "v") #'ement-room-view-event)
+    (define-key map (kbd "D") #'ement-room-download-file)
 
     ;; Users
     (define-key map (kbd "u RET") #'ement-send-direct-message)
@@ -5844,7 +5845,8 @@ For use in `completion-at-point-functions'."
               ("s r" "Send reaction" ement-room-send-reaction)
               ("s e" "Send emote" ement-room-send-emote)
               ("s f" "Send file" ement-room-send-file)
-              ("s i" "Send image" ement-room-send-image)]
+              ("s i" "Send image" ement-room-send-image)
+              ("D" "Download event media" ement-room-download-file)]
              ["Users"
               ("u RET" "Send direct message" ement-send-direct-message)
               ("u i" "Invite user" ement-invite-user)


### PR DESCRIPTION
Add a function for downloading media, and use it as the default action for m.audio, m.file and m.video.

Now that authenticated media is the expected situation opening these as links in an external browser no longer works, so try this instead.

"Open in the chosen application for this mime type" would be nice as well, but based on looking at the way Gnus does this it seems harder than expected. Perhaps there is something I don't understand here..