### PR TITLE
Fix: (ement-room.el) Invalid JSON type

### DIFF
--- a/ement-room.el
+++ b/ement-room.el
@@ -2640,7 +2640,9 @@ the previously oldest event."
                (endpoint (format "rooms/%s/typing/%s"
                                  (url-hexify-string room-id) (url-hexify-string user-id)))
                (data (ement-alist "typing" typing "timeout" 20000)))
-    (ement-api session endpoint :method 'put :data (json-encode data)
+    (ement-api session endpoint :method 'put
+      :data (let ((json-false nil))
+              (json-encode data))
       ;; We don't really care about the response, I think.
       :then #'ignore)))
 


### PR DESCRIPTION
The JSON sent to cancel the typing notification was rejected by the server:

```
Error running timer ‘plz--respond’: (ement-api-error "400: M_BAD_JSON:
deserialization failed: invalid type: null, expected a boolean at line
1 column 30")
```