### PR TITLE
fix: Make sure the matched string is not simply a substring of a bigger word

### DIFF
--- a/ement-room.el
+++ b/ement-room.el
@@ -4250,7 +4250,8 @@ HTML is rendered to Emacs text using `shr-insert-document'."
     (when body
       (cl-macrolet ((matches-body-p
                       (form) `(when-let ((string ,form))
-                                (string-match-p (regexp-quote string) body))))
+                                (string-match-p (rx word-start (literal string) word-end)
+                                                body))))
         (or (matches-body-p (ement-user-username user))
             (matches-body-p (ement--user-displayname-in room user))
             (matches-body-p (ement-user-id user)))))))


### PR DESCRIPTION
If one displayname is 'sam' and another's nickname is 'samy', then all events to samy were recognized as mentionning sam as well.

See the issue https://github.com/alphapapa/ement.el/issues/240