### PR TITLE
Fix: (ement-room-compose-buffer-string-trimmed) Whitespace-only buffers

### DIFF
--- a/ement-room.el
+++ b/ement-room.el
@@ -4448,12 +4448,15 @@ To be called from a minibuffer opened from
 
 (defun ement-room-compose-buffer-string-trimmed ()
   "Like `buffer-string' trimmed with `string-trim'."
-  (buffer-substring-no-properties (progn (goto-char (point-min))
-                                         (skip-chars-forward " \t\r\n")
-                                         (point))
-                                  (progn (goto-char (point-max))
-                                         (skip-chars-backward " \t\r\n")
-                                         (point))))
+  (save-excursion
+    (save-restriction
+      (goto-char (point-min))
+      (skip-chars-forward " \t\r\n")
+      (narrow-to-region (point) (point-max))
+      (buffer-substring-no-properties
+       (point) (progn (goto-char (point-max))
+                      (skip-chars-backward " \t\r\n")
+                      (point))))))
 
 (defun ement-room-compose-send-prepare ()
   "Bindings for `ement-room-compose-send' and `ement-room-compose-send-direct'."


### PR DESCRIPTION
Do not return the complete buffer string when the buffer contains only whitespace.

Addresses #339 for the compose-buffer case.