### PR TITLE
Add: (ement-room-latest-timestamp-event-types) New option

### DIFF
--- a/ement-room.el
+++ b/ement-room.el
@@ -5310,29 +5310,31 @@ STRUCT should be an `ement-room-membership-events' struct."
               (and (bound-and-true-p ement-room-latest-timestamp-event-types)
                    (consp ement-room-latest-timestamp-event-types)
                    ement-room-latest-timestamp-event-types)
-              '("m.reaction"
-                "m.room.avatar"
-                "m.room.canonical_alias"
-                "m.room.create"
-                "m.room.guest_access"
-                "m.room.history_visibility"
-                "m.room.join_rules"
-                "m.room.member"
-                "m.room.message"
-                "m.room.name"
-                "m.room.power_levels"
-                "m.room.redaction"
-                "m.room.related_groups"
-                "m.room.third_party_invite"
-                "m.room.tombstone"
-                "m.room.topic"
-                "m.space.child"))
+              '(("m.reaction" . "A reaction to a previous event.")
+                ("m.room.avatar" . "A picture that is associated with the room.")
+                ("m.room.canonical_alias" . "Which room alias is canonical, and which other aliases exist.")
+                ("m.room.create" . "The first event in a room; the root of all other events.")
+                ("m.room.join_rules" . "Requirements for users to join the room.")
+                ("m.room.member" . "Adjusts the room membership state for a user.")
+                ("m.room.message" . "A room message (not limited to text).")
+                ("m.room.name" . "The human-friendly name for the room.")
+                ("m.room.power_levels" . "This event specifies the minimum level a user must have in order to perform a certain action. It also specifies the levels of each user in the room.")
+                ("m.room.redaction" . "Describes which event has been redacted, by whom, and why.")
+                ("m.room.tombstone" . "Signifies that a room has been upgraded to a different room version.")
+                ("m.room.topic" . "A short message detailing what is currently being discussed in the room."))
+              nil)
+      :key (lambda (a) (if (consp a) (car a) a))
       :test 'equal)
-     #'string-lessp)))
+     (lambda (a b)
+       (string-lessp (if (consp a) (car a) a)
+                     (if (consp b) (car b) b))))))
 
 (defun ement-room--events-checklist-convert-widget (widget)
   "Update the widget with the current known events."
-  (widget-put widget :args (mapcar (lambda (x) (list 'const x))
+  (widget-put widget :args (mapcar (lambda (x)
+                                     (if (consp x)
+                                         (list 'const (car x) :tag (cdr x))
+                                       (list 'const x)))
                                    (ement-room--known-events)))
   widget)
 
@@ -5341,7 +5343,19 @@ STRUCT should be an `ement-room-membership-events' struct."
   :convert-widget 'ement-room--events-checklist-convert-widget)
 
 (defcustom ement-room-latest-timestamp-event-types t
-  "Event types which affect the latest timestamp of a room."
+  "Event types which affect the latest timestamp of a room.
+
+The room list buffer's \"Latest\" column reflects the most recent
+matching event in the current session.
+
+Note that there is no fixed set of valid event names.  The pre-populated
+values for this option are a combination of some common Matrix events,
+and events which have been seen in the current session.  The suggested
+values may therefore change from one session to another.  Events which
+are not listed by default can be added manually.
+
+Refer to URL `https://spec.matrix.org/latest/client-server-api/#events'
+for information about Matrix events."
   :type `(choice (const :tag "All events" t)
                  (list :tag "Specified events"
                        (ement-events-checklist :inline t :greedy t)

--- a/ement-room.el
+++ b/ement-room.el
@@ -2514,6 +2514,8 @@ To be used in `ement-room-view-hook', which see."
         (ement-event data)
         (otherwise (user-error "No event at point"))))))
 
+(defvar ement-room-latest-timestamp-event-types)
+
 (cl-defun ement-room-retro-callback (room session data
                                           &key (set-prev-batch t))
   "Push new DATA to ROOM on SESSION and add events to room buffer.
@@ -2534,7 +2536,8 @@ before the earliest-seen message)."
                ;; likely very few compared to the number of timeline events, which is
                ;; what the user is interested in (e.g. when loading 1000 earlier
                ;; messages in #emacs:matrix.org, only 31 state events were received).
-               (progress-max-value (* 3 num-events)))
+               (progress-max-value (* 3 num-events))
+               (ts 0))
     ;; NOTE: Put the newly retrieved events at the end of the slots, because they should be
     ;; older events.  But reverse them first, because we're using "dir=b", which the
     ;; spec says causes the events to be returned in reverse-chronological order, and we
@@ -2549,6 +2552,11 @@ before the earliest-seen message)."
     ;; Append state events.
     (cl-loop for event across-ref state
              do (setf event (ement--make-event event))
+             (when (and (> (ement-event-origin-server-ts event) ts)
+                        (or (eq ement-room-latest-timestamp-event-types t)
+                            (member (ement-event-type event)
+                                    ement-room-latest-timestamp-event-types)))
+               (setf ts (ement-event-origin-server-ts event)))
              finally do (setf (ement-room-state room)
                               (append (ement-room-state room) (append state nil))))
     (ement-with-progress-reporter (:reporter ("Ement: Processing earlier events..." 0 progress-max-value))
@@ -2565,13 +2573,21 @@ before the earliest-seen message)."
                     ;; New event.
                     (setf event (ement--make-event event))
                     ;; HACK: Put events on events table.  See FIXME above about using the event hook.
-                    (ement--put-event event nil session))
+                    (ement--put-event event nil session)
+                    (when (and (> (ement-event-origin-server-ts event) ts)
+                               (or (eq ement-room-latest-timestamp-event-types t)
+                                   (member (ement-event-type event)
+                                           ement-room-latest-timestamp-event-types)))
+                      (setf ts (ement-event-origin-server-ts event))))
                (ement-progress-update)
                finally do
                (setf chunk (seq-remove #'null chunk)
                      (ement-room-timeline room) (append (ement-room-timeline room) chunk)))
+      ;; Update room's latest-timestamp slot.
+      (when (> ts (or (ement-room-latest-ts room) 0))
+        (setf (ement-room-latest-ts room) ts))
+      ;; Insert events into the room's buffer.
       (when buffer
-        ;; Insert events into the room's buffer.
         (with-current-buffer buffer
           (save-window-excursion
             ;; NOTE: See note in `ement--update-room-buffers'.
@@ -5270,6 +5286,67 @@ STRUCT should be an `ement-room-membership-events' struct."
                                                            (propertize type 'face 'bold)
                                                            (string-join users ", ")))
                                   "; "))))))))
+
+;; `ement-events-checklist' widget for `ement-room-latest-timestamp-event-types'.
+
+(defun ement-room--known-events ()
+  "Combined list of names of common/known events and observed session events."
+  ;; Without separately persisting a list of session-supplied event names,
+  ;; there's no way to distinguish user-supplied events from session-supplied
+  ;; events (when the latter may vary), and so we make them all checkboxes.
+  ;; This ensures that events which were checkboxes when the user initially
+  ;; customized the list do not later appear in the `editable-list' section
+  ;; of the widget, if the current session does not yet contain those events.
+  ;; This does mean that genuine user-added events end up as checkboxes too,
+  ;; but, of the two approaches, this seemed like the preferable way around.
+  (let (events)
+    (dolist (sess ement-sessions)
+      (dolist (event (hash-table-values (ement-session-events (cdr sess))))
+        (unless (member (ement-event-type event) events)
+          (push (ement-event-type event) events))))
+    (sort
+     (cl-delete-duplicates
+      (append events
+              (and (bound-and-true-p ement-room-latest-timestamp-event-types)
+                   (consp ement-room-latest-timestamp-event-types)
+                   ement-room-latest-timestamp-event-types)
+              '("m.reaction"
+                "m.room.avatar"
+                "m.room.canonical_alias"
+                "m.room.create"
+                "m.room.guest_access"
+                "m.room.history_visibility"
+                "m.room.join_rules"
+                "m.room.member"
+                "m.room.message"
+                "m.room.name"
+                "m.room.power_levels"
+                "m.room.redaction"
+                "m.room.related_groups"
+                "m.room.third_party_invite"
+                "m.room.tombstone"
+                "m.room.topic"
+                "m.space.child"))
+      :test 'equal)
+     #'string-lessp)))
+
+(defun ement-room--events-checklist-convert-widget (widget)
+  "Update the widget with the current known events."
+  (widget-put widget :args (mapcar (lambda (x) (list 'const x))
+                                   (ement-room--known-events)))
+  widget)
+
+(define-widget 'ement-events-checklist 'checklist
+  "Checklist of names of known Matrix events in all current sessions."
+  :convert-widget 'ement-room--events-checklist-convert-widget)
+
+(defcustom ement-room-latest-timestamp-event-types t
+  "Event types which affect the latest timestamp of a room."
+  :type `(choice (const :tag "All events" t)
+                 (list :tag "Specified events"
+                       (ement-events-checklist :inline t :greedy t)
+                       (editable-list :inline t (string :tag "Event"))))
+  :group 'ement-room)
 
 ;;;;; Images
 

--- a/ement.el
+++ b/ement.el
@@ -113,6 +113,7 @@ by users; ones who do so should know what they're doing.")
 ;; From other files.
 (defvar ement-room-avatar-max-width)
 (defvar ement-room-avatar-max-height)
+(defvar ement-room-latest-timestamp-event-types)
 
 ;;;; Customization
 
@@ -740,7 +741,10 @@ Also used for left rooms, in which case STATUS should be set to
                                 do (push event (,accessor room))
                                 (when (ement--sync-messages-p session)
                                   (ement-progress-update))
-                                (when (> (ement-event-origin-server-ts event) ts)
+                                (when (and (> (ement-event-origin-server-ts event) ts)
+                                           (or (eq ement-room-latest-timestamp-event-types t)
+                                               (member (ement-event-type event)
+                                                       ement-room-latest-timestamp-event-types)))
                                   (setf ts (ement-event-origin-server-ts event))))
                        ;; One would think that one should use `maximizing' here, but, completely
                        ;; inexplicably, it sometimes returns nil, even when every single value it's comparing


### PR DESCRIPTION
Draft PR for issue #176.

The following documentation from the code explains the new option:

> Event types which affect the latest timestamp of a room.
> 
> The room list buffer's "Latest" column reflects the most recent
> matching event in the current session.
> 
> Note that there is no fixed set of valid event names.  The
> pre-populated values for this option are a combination of some common
> Matrix events, and events which have been seen in the current session.
> The suggested values may therefore change from one session to another.
> Events which are not listed by default can be added manually.
> 
> Refer to URL https://spec.matrix.org/latest/client-server-api/#events
> for information about Matrix events.
